### PR TITLE
Add tests for Reddit feed and multi-book comparison

### DIFF
--- a/app/api/reddit-feed/route.ts
+++ b/app/api/reddit-feed/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+
+export interface RedditPost {
+  id: string;
+  title: string;
+  url: string;
+}
+
+export async function GET() {
+  try {
+    const res = await fetch("https://www.reddit.com/r/zen.json");
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: "Failed to fetch Reddit feed" },
+        { status: res.status }
+      );
+    }
+
+    let data: any;
+    try {
+      data = await res.json();
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid JSON from Reddit" },
+        { status: 502 }
+      );
+    }
+
+    const children = data?.data?.children;
+    if (!Array.isArray(children)) {
+      return NextResponse.json(
+        { error: "Unexpected Reddit response structure" },
+        { status: 502 }
+      );
+    }
+
+    try {
+      const posts: RedditPost[] = children.map((c: any) => ({
+        id: c.data.id,
+        title: c.data.title,
+        url: c.data.url,
+      }));
+      return NextResponse.json(posts);
+    } catch {
+      return NextResponse.json(
+        { error: "Failed to parse Reddit posts" },
+        { status: 500 }
+      );
+    }
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to reach Reddit" },
+      { status: 502 }
+    );
+  }
+}

--- a/tests/multi-book-compare.test.ts
+++ b/tests/multi-book-compare.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import initSqlJs from 'sql.js'
+
+describe('multi-book comparison', () => {
+  it('returns verses for multiple books', async () => {
+    const SQL = await initSqlJs()
+    const db = new SQL.Database()
+    db.run(`
+      CREATE TABLE books (id TEXT PRIMARY KEY, title TEXT);
+      CREATE TABLE verses (id TEXT PRIMARY KEY, number INTEGER, book_id TEXT);
+      INSERT INTO books (id, title) VALUES ('b1','Book 1'), ('b2','Book 2');
+      INSERT INTO verses (id, number, book_id) VALUES ('v1',1,'b1'), ('v2',1,'b2');
+    `)
+    const res = db.exec(
+      "SELECT b.id as bookId, v.id as verseId, v.number as number FROM books b JOIN verses v ON b.id = v.book_id WHERE b.id IN ('b1','b2') ORDER BY b.id, v.number"
+    )
+    const rows = res[0].values.map((r) => ({ bookId: r[0] as string, verseId: r[1] as string, number: r[2] as number }))
+    const result = rows.reduce<Record<string, { id: string; number: number }[]>>((acc, row) => {
+      acc[row.bookId] = acc[row.bookId] || []
+      acc[row.bookId].push({ id: row.verseId, number: row.number })
+      return acc
+    }, {})
+    expect(result).toEqual({
+      b1: [{ id: 'v1', number: 1 }],
+      b2: [{ id: 'v2', number: 1 }]
+    })
+  })
+})

--- a/tests/reddit-feed.test.ts
+++ b/tests/reddit-feed.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest'
+import { GET } from '../app/api/reddit-feed/route'
+
+const mockResponse = {
+  data: {
+    children: [
+      {
+        data: { id: '1', title: 'Post', url: 'https://example.com' }
+      }
+    ]
+  }
+}
+
+describe('reddit feed API', () => {
+  it('returns parsed posts', async () => {
+    const originalFetch = global.fetch
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(mockResponse) } as any)
+
+    const res = await GET()
+    const posts = await res.json()
+
+    expect(posts).toEqual([
+      { id: '1', title: 'Post', url: 'https://example.com' }
+    ])
+
+    global.fetch = originalFetch
+  })
+
+  it('handles invalid response structure', async () => {
+    const originalFetch = global.fetch
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) } as any)
+
+    const res = await GET()
+
+    expect(res.status).toBe(502)
+    const body = await res.json()
+    expect(body.error).toBeDefined()
+
+    global.fetch = originalFetch
+  })
+
+  it('handles fetch failure', async () => {
+    const originalFetch = global.fetch
+    global.fetch = vi.fn().mockRejectedValue(new Error('network error'))
+
+    const res = await GET()
+
+    expect(res.status).toBe(502)
+    const body = await res.json()
+    expect(body.error).toBe('Failed to reach Reddit')
+
+    global.fetch = originalFetch
+  })
+
+  it('handles non-OK responses', async () => {
+    const originalFetch = global.fetch
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500, json: () => Promise.resolve({}) } as any)
+
+    const res = await GET()
+
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error).toBe('Failed to fetch Reddit feed')
+
+    global.fetch = originalFetch
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    environment: 'node'
+  }
+})


### PR DESCRIPTION
## Summary
- add Reddit feed API route and test mocking network call
- test multi-book comparison using in-memory SQL database
- configure Vitest to include tests
- improve Reddit feed API error handling and add test for invalid responses
- cover Reddit feed error cases for fetch failure and non-OK responses

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689470e36c888323b97b7d9fd9f79af1