### PR TITLE
feat: add user profile page with follow API

### DIFF
--- a/app/api/users/[userId]/follow.ts
+++ b/app/api/users/[userId]/follow.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { follows } from "@/lib/schema"
+import { eq, and } from "drizzle-orm"
+import { v4 as uuidv4 } from "uuid"
+
+export async function POST(
+  req: Request,
+  { params }: { params: { userId: string } }
+) {
+  const { followerId } = await req.json()
+  if (!followerId) {
+    return NextResponse.json({ error: "Missing followerId" }, { status: 400 })
+  }
+
+  await db.insert(follows).values({
+    id: uuidv4(),
+    followerId,
+    followingId: params.userId,
+  })
+
+  return NextResponse.json({ success: true })
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: { userId: string } }
+) {
+  const { followerId } = await req.json()
+  if (!followerId) {
+    return NextResponse.json({ error: "Missing followerId" }, { status: 400 })
+  }
+
+  await db
+    .delete(follows)
+    .where(
+      and(
+        eq(follows.followerId, followerId),
+        eq(follows.followingId, params.userId)
+      )
+    )
+
+  return NextResponse.json({ success: true })
+}
+

--- a/app/users/[userId]/page.tsx
+++ b/app/users/[userId]/page.tsx
@@ -1,0 +1,176 @@
+import { notFound } from "next/navigation"
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { db } from "@/lib/db"
+import { users, notes, comments } from "@/lib/schema"
+import { eq, desc, sql } from "drizzle-orm"
+
+export const revalidate = 60
+
+interface PageProps {
+  params: { userId: string }
+  searchParams: { [key: string]: string | string[] | undefined }
+}
+
+const PAGE_SIZE = 5
+
+export default async function UserPage({ params, searchParams }: PageProps) {
+  const user = await db.query.users.findFirst({
+    where: eq(users.id, params.userId),
+  })
+
+  if (!user) {
+    notFound()
+  }
+
+  const notesPage = Number(searchParams?.notesPage ?? 1)
+  const commentsPage = Number(searchParams?.commentsPage ?? 1)
+
+  const [userNotes, notesCountRes] = await Promise.all([
+    db.query.notes.findMany({
+      where: eq(notes.userId, params.userId),
+      orderBy: (notes, { desc }) => [desc(notes.createdAt)],
+      limit: PAGE_SIZE,
+      offset: (notesPage - 1) * PAGE_SIZE,
+    }),
+    db
+      .select({ count: sql<number>`count(*)` })
+      .from(notes)
+      .where(eq(notes.userId, params.userId)),
+  ])
+  const notesCount = Number(notesCountRes[0]?.count || 0)
+  const totalNotesPages = Math.max(1, Math.ceil(notesCount / PAGE_SIZE))
+
+  const [userComments, commentsCountRes] = await Promise.all([
+    db.query.comments.findMany({
+      where: eq(comments.userId, params.userId),
+      orderBy: (comments, { desc }) => [desc(comments.createdAt)],
+      limit: PAGE_SIZE,
+      offset: (commentsPage - 1) * PAGE_SIZE,
+    }),
+    db
+      .select({ count: sql<number>`count(*)` })
+      .from(comments)
+      .where(eq(comments.userId, params.userId)),
+  ])
+  const commentsCount = Number(commentsCountRes[0]?.count || 0)
+  const totalCommentsPages = Math.max(1, Math.ceil(commentsCount / PAGE_SIZE))
+
+  return (
+    <main className="p-4 md:p-10">
+      <div className="max-w-3xl mx-auto space-y-8">
+        <section className="flex items-center gap-4">
+          <Avatar className="h-16 w-16">
+            <AvatarImage src={user.avatar ?? undefined} alt={user.username} />
+            <AvatarFallback>{user.username.charAt(0)}</AvatarFallback>
+          </Avatar>
+          <div>
+            <h1 className="text-2xl font-bold">{user.username}</h1>
+            {user.bio && <p className="text-muted-foreground">{user.bio}</p>}
+            <p className="text-sm text-muted-foreground">
+              Joined {user.createdAt.toDateString()}
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-4">Notes</h2>
+          <ul className="space-y-2">
+            {userNotes.map((note) => (
+              <li key={note.id} className="p-4 border rounded-md">
+                <p>{note.content}</p>
+              </li>
+            ))}
+            {userNotes.length === 0 && (
+              <li className="text-sm text-muted-foreground">No notes yet.</li>
+            )}
+          </ul>
+          {totalNotesPages > 1 && (
+            <Pagination className="mt-4">
+              <PaginationContent>
+                <PaginationItem>
+                  {notesPage > 1 && (
+                    <PaginationPrevious
+                      href={`?notesPage=${notesPage - 1}&commentsPage=${commentsPage}`}
+                    />
+                  )}
+                </PaginationItem>
+                {Array.from({ length: totalNotesPages }).map((_, i) => (
+                  <PaginationItem key={i}>
+                    <PaginationLink
+                      href={`?notesPage=${i + 1}&commentsPage=${commentsPage}`}
+                      isActive={notesPage === i + 1}
+                    >
+                      {i + 1}
+                    </PaginationLink>
+                  </PaginationItem>
+                ))}
+                <PaginationItem>
+                  {notesPage < totalNotesPages && (
+                    <PaginationNext
+                      href={`?notesPage=${notesPage + 1}&commentsPage=${commentsPage}`}
+                    />
+                  )}
+                </PaginationItem>
+              </PaginationContent>
+            </Pagination>
+          )}
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-4">Comments</h2>
+          <ul className="space-y-2">
+            {userComments.map((comment) => (
+              <li key={comment.id} className="p-4 border rounded-md">
+                <p>{comment.content}</p>
+              </li>
+            ))}
+            {userComments.length === 0 && (
+              <li className="text-sm text-muted-foreground">
+                No comments yet.
+              </li>
+            )}
+          </ul>
+          {totalCommentsPages > 1 && (
+            <Pagination className="mt-4">
+              <PaginationContent>
+                <PaginationItem>
+                  {commentsPage > 1 && (
+                    <PaginationPrevious
+                      href={`?notesPage=${notesPage}&commentsPage=${commentsPage - 1}`}
+                    />
+                  )}
+                </PaginationItem>
+                {Array.from({ length: totalCommentsPages }).map((_, i) => (
+                  <PaginationItem key={i}>
+                    <PaginationLink
+                      href={`?notesPage=${notesPage}&commentsPage=${i + 1}`}
+                      isActive={commentsPage === i + 1}
+                    >
+                      {i + 1}
+                    </PaginationLink>
+                  </PaginationItem>
+                ))}
+                <PaginationItem>
+                  {commentsPage < totalCommentsPages && (
+                    <PaginationNext
+                      href={`?notesPage=${notesPage}&commentsPage=${commentsPage + 1}`}
+                    />
+                  )}
+                </PaginationItem>
+              </PaginationContent>
+            </Pagination>
+          )}
+        </section>
+      </div>
+    </main>
+  )
+}
+

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -10,6 +10,8 @@ export const users = pgTable("users", {
   isGuest: boolean("is_guest").default(false).notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").notNull(),
+  avatar: text("avatar"),
+  bio: text("bio"),
 })
 
 // Book table
@@ -81,6 +83,29 @@ export const favorites = pgTable(
   },
 )
 
+// Follow table
+export const follows = pgTable(
+  "follows",
+  {
+    id: text("id").primaryKey(),
+    followerId: text("follower_id")
+      .notNull()
+      .references(() => users.id),
+    followingId: text("following_id")
+      .notNull()
+      .references(() => users.id),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => {
+    return {
+      followerFollowingUnique: uniqueIndex("follower_following_unique").on(
+        table.followerId,
+        table.followingId
+      ),
+    }
+  }
+)
+
 // Note table
 export const notes = pgTable("notes", {
   id: text("id").primaryKey(),
@@ -145,6 +170,8 @@ export const usersRelations = relations(users, ({ many }) => ({
   notes: many(notes),
   comments: many(comments),
   sessions: many(sessions),
+  followers: many(follows, { relationName: "following" }),
+  following: many(follows, { relationName: "follower" }),
 }))
 
 export const favoritesRelations = relations(favorites, ({ one }) => ({
@@ -155,6 +182,19 @@ export const favoritesRelations = relations(favorites, ({ one }) => ({
   book: one(books, {
     fields: [favorites.bookId],
     references: [books.id],
+  }),
+}))
+
+export const followsRelations = relations(follows, ({ one }) => ({
+  follower: one(users, {
+    relationName: "follower",
+    fields: [follows.followerId],
+    references: [users.id],
+  }),
+  following: one(users, {
+    relationName: "following",
+    fields: [follows.followingId],
+    references: [users.id],
   }),
 }))
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,10 +19,14 @@ model User {
   isGuest   Boolean  @default(false)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-  
+  avatar    String?
+  bio       String?
+
   favorites Favorite[]
   notes     Note[]
   comments  Comment[]
+  followers Follow[] @relation("following")
+  following Follow[] @relation("follower")
 }
 
 model Book {
@@ -85,6 +89,17 @@ model Favorite {
   updatedAt DateTime @updatedAt
 
   @@unique([userId, bookId])
+}
+
+model Follow {
+  id          String   @id @default(cuid())
+  followerId  String
+  followingId String
+  follower    User     @relation("follower", fields: [followerId], references: [id])
+  following   User     @relation("following", fields: [followingId], references: [id])
+  createdAt   DateTime @default(now())
+
+  @@unique([followerId, followingId])
 }
 
 model Note {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -70,6 +70,8 @@ async function main() {
       username: "demo",
       password: "$2a$10$GQH.xZm5DqJu8HgFtuhZEOsj7dQQgWlHhbwwZ1QzPJ8MzJyppyXOq", // hashed 'password123'
       isGuest: false,
+      avatar: "/placeholder.svg?height=64&width=64&text=D",
+      bio: "Demo account for exploring the app",
     },
   })
 
@@ -84,6 +86,8 @@ async function main() {
       username: "guest",
       password: "$2a$10$GQH.xZm5DqJu8HgFtuhZEOsj7dQQgWlHhbwwZ1QzPJ8MzJyppyXOq", // hashed 'password123'
       isGuest: true,
+      avatar: "/placeholder.svg?height=64&width=64&text=G",
+      bio: "Guest account",
     },
   })
 


### PR DESCRIPTION
## Summary
- add user profile page with avatar, bio, join date and paginated notes/comments
- support following users via new follow/unfollow API
- extend schemas for user profile fields and follows

## Testing
- `pnpm test`
- `pnpm lint` *(fails: interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689477cc26b4832383813e2fa8330776