### PR TITLE
feat: add highlights

### DIFF
--- a/app/api/highlights/route.ts
+++ b/app/api/highlights/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server"
+import { eq } from "drizzle-orm"
+
+import { db } from "@/lib/db"
+import { highlights } from "@/lib/schema"
+
+export async function POST(req: NextRequest) {
+  const { userId, verseId, start, end, note, isPublic = false } = await req.json()
+  const [highlight] = await db
+    .insert(highlights)
+    .values({
+      id: crypto.randomUUID(),
+      userId,
+      verseId,
+      start,
+      end,
+      note,
+      isPublic,
+      updatedAt: new Date(),
+    })
+    .returning()
+
+  return NextResponse.json(highlight)
+}
+
+export async function PATCH(req: NextRequest) {
+  const { id, isPublic } = await req.json()
+  const [highlight] = await db
+    .update(highlights)
+    .set({ isPublic, updatedAt: new Date() })
+    .where(eq(highlights.id, id))
+    .returning()
+
+  return NextResponse.json(highlight)
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const verseId = searchParams.get("verseId")
+  const userId = searchParams.get("userId")
+
+  if (!verseId) {
+    return NextResponse.json([])
+  }
+
+  const rows = await db.select().from(highlights).where(eq(highlights.verseId, verseId))
+  const filtered = userId
+    ? rows.filter((h) => h.isPublic || h.userId === userId)
+    : rows.filter((h) => h.isPublic)
+  return NextResponse.json(filtered)
+}

--- a/components/verse-viewer.tsx
+++ b/components/verse-viewer.tsx
@@ -1,0 +1,75 @@
+"use client"
+
+import { useState } from "react"
+
+interface VerseViewerProps {
+  verseId: string
+  text: string
+}
+
+interface Selection {
+  start: number
+  end: number
+}
+
+export function VerseViewer({ verseId, text }: VerseViewerProps) {
+  const [selection, setSelection] = useState<Selection | null>(null)
+  const [note, setNote] = useState("")
+  const [showToolbar, setShowToolbar] = useState(false)
+
+  const handleMouseUp = () => {
+    const sel = window.getSelection()
+    if (!sel || sel.isCollapsed) {
+      setShowToolbar(false)
+      return
+    }
+    const start = Math.min(sel.anchorOffset, sel.focusOffset)
+    const end = Math.max(sel.anchorOffset, sel.focusOffset)
+    setSelection({ start, end })
+    setShowToolbar(true)
+  }
+
+  const saveHighlight = async (withNote: boolean) => {
+    if (!selection) return
+    await fetch("/api/highlights", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        verseId,
+        start: selection.start,
+        end: selection.end,
+        note: withNote ? note : undefined,
+      }),
+    })
+    setSelection(null)
+    setNote("")
+    setShowToolbar(false)
+  }
+
+  return (
+    <div onMouseUp={handleMouseUp} className="relative">
+      <p>{text}</p>
+      {showToolbar && (
+        <div className="absolute bg-background border p-2 rounded shadow flex gap-2">
+          <button onClick={() => saveHighlight(false)} className="text-sm">
+            Highlight
+          </button>
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              placeholder="Add note"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              className="border p-1 text-sm"
+            />
+            <button onClick={() => saveHighlight(true)} className="text-sm">
+              Save
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default VerseViewer

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -109,6 +109,23 @@ export const comments = pgTable("comments", {
   updatedAt: timestamp("updated_at").notNull(),
 })
 
+// Highlight table
+export const highlights = pgTable("highlights", {
+  id: text("id").primaryKey(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id),
+  verseId: text("verse_id")
+    .notNull()
+    .references(() => verses.id),
+  start: integer("start").notNull(),
+  end: integer("end").notNull(),
+  note: text("note"),
+  isPublic: boolean("is_public").default(false).notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").notNull(),
+})
+
 // Session table
 export const sessions = pgTable("sessions", {
   id: text("id").primaryKey(),
@@ -130,6 +147,7 @@ export const versesRelations = relations(verses, ({ one, many }) => ({
   translations: many(translations),
   notes: many(notes),
   comments: many(comments),
+  highlights: many(highlights),
 }))
 
 export const translationsRelations = relations(translations, ({ one, many }) => ({
@@ -145,6 +163,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   notes: many(notes),
   comments: many(comments),
   sessions: many(sessions),
+  highlights: many(highlights),
 }))
 
 export const favoritesRelations = relations(favorites, ({ one }) => ({
@@ -176,6 +195,17 @@ export const commentsRelations = relations(comments, ({ one }) => ({
   }),
   verse: one(verses, {
     fields: [comments.verseId],
+    references: [verses.id],
+  }),
+}))
+
+export const highlightsRelations = relations(highlights, ({ one }) => ({
+  user: one(users, {
+    fields: [highlights.userId],
+    references: [users.id],
+  }),
+  verse: one(verses, {
+    fields: [highlights.verseId],
     references: [verses.id],
   }),
 }))


### PR DESCRIPTION
## Summary
- add highlights table linking users to verse segments
- add verse viewer for selection and saving highlights or notes
- add highlights API with public/private toggle

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689477ce050c8323b309ae2d7042e9f0