### PR TITLE
Add verse view tracking and user dashboards

### DIFF
--- a/app/api/verse-views/route.ts
+++ b/app/api/verse-views/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { verseViews } from "@/lib/schema"
+
+export async function POST(req: Request) {
+  const { verseId, translationId, userId } = await req.json()
+  if (!verseId) {
+    return NextResponse.json({ error: "Missing verseId" }, { status: 400 })
+  }
+  await db.insert(verseViews).values({
+    id: crypto.randomUUID(),
+    verseId,
+    translationId,
+    userId,
+  })
+  return NextResponse.json({ success: true })
+}

--- a/app/api/verse-views/route.ts
+++ b/app/api/verse-views/route.ts
@@ -7,11 +7,20 @@ export async function POST(req: Request) {
   if (!verseId) {
     return NextResponse.json({ error: "Missing verseId" }, { status: 400 })
   }
-  await db.insert(verseViews).values({
-    id: crypto.randomUUID(),
-    verseId,
-    translationId,
-    userId,
-  })
-  return NextResponse.json({ success: true })
+  try {
+    await db.insert(verseViews).values({
+      id: crypto.randomUUID(),
+      verseId,
+      translationId,
+      userId,
+    })
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error"
+    console.error("Failed to record verse view:", err)
+    return NextResponse.json(
+      { error: "Failed to record verse view", details: message },
+      { status: 500 }
+    )
+  }
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,54 @@
+import { db } from "@/lib/db"
+import { favorites, notes } from "@/lib/schema"
+import { eq } from "drizzle-orm"
+
+export default async function DashboardPage() {
+  const userId = "demo-user"
+
+  const userFavorites = await db.query.favorites.findMany({
+    where: eq(favorites.userId, userId),
+    with: { book: true },
+  })
+
+  const userNotes = await db.query.notes.findMany({
+    where: eq(notes.userId, userId),
+    with: { verse: true },
+  })
+
+  return (
+    <main className="flex min-h-screen flex-col items-center p-4 md:p-24">
+      <div className="max-w-4xl w-full">
+        <h1 className="text-3xl font-bold mb-6">Your Dashboard</h1>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-semibold mb-4">Highlights</h2>
+          <ul className="space-y-2">
+            {userFavorites.map((fav) => (
+              <li key={fav.id} className="p-2 border rounded">
+                {fav.book.title}
+              </li>
+            ))}
+            {userFavorites.length === 0 && (
+              <p className="text-sm text-muted-foreground">No favorites yet.</p>
+            )}
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold mb-4">Notes</h2>
+          <ul className="space-y-2">
+            {userNotes.map((note) => (
+              <li key={note.id} className="p-2 border rounded">
+                <div className="font-medium">Verse {note.verse.number}</div>
+                <p className="text-sm mt-1">{note.content}</p>
+              </li>
+            ))}
+            {userNotes.length === 0 && (
+              <p className="text-sm text-muted-foreground">No notes yet.</p>
+            )}
+          </ul>
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,0 +1,38 @@
+import { db } from "@/lib/db"
+import { verseViews, translations } from "@/lib/schema"
+import { eq, sql } from "drizzle-orm"
+
+export const revalidate = 60
+
+export default async function StatsPage() {
+  const translatorLeaderboard = await db
+    .select({
+      translator: translations.translator,
+      views: sql<number>`count(${verseViews.id})`.as("views"),
+    })
+    .from(verseViews)
+    .leftJoin(translations, eq(verseViews.translationId, translations.id))
+    .groupBy(translations.translator)
+    .orderBy(sql`count(${verseViews.id}) desc`)
+
+  return (
+    <main className="flex min-h-screen flex-col items-center p-4 md:p-24">
+      <div className="max-w-3xl w-full">
+        <h1 className="text-3xl font-bold mb-6">Contributor Leaderboard</h1>
+        <div className="space-y-2">
+          {translatorLeaderboard.map((row, idx) => (
+            <div key={row.translator ?? "Unknown"} className="flex justify-between border-b py-2">
+              <span>
+                {idx + 1}. {row.translator ?? "Unknown"}
+              </span>
+              <span className="font-medium">{row.views} views</span>
+            </div>
+          ))}
+          {translatorLeaderboard.length === 0 && (
+            <p className="text-sm text-muted-foreground">No data yet.</p>
+          )}
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/components/translation-view.tsx
+++ b/components/translation-view.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+interface TranslationViewProps {
+  translation: {
+    id: string
+    text: string
+    translator: string
+    language: string
+  }
+  verseId: string
+}
+
+export function TranslationView({ translation, verseId }: TranslationViewProps) {
+  function handleClick() {
+    fetch("/api/verse-views", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ verseId, translationId: translation.id }),
+    })
+  }
+
+  return (
+    <div
+      onClick={handleClick}
+      className="border-b pb-4 last:border-b-0 last:pb-0 cursor-pointer"
+    >
+      <h3 className="font-medium text-lg mb-2">
+        Translation by {translation.translator}
+      </h3>
+      <p className="text-gray-800 whitespace-pre-line">{translation.text}</p>
+      <p className="text-sm text-gray-500 mt-2">Language: {translation.language}</p>
+    </div>
+  )
+}

--- a/components/verse-view-tracker.tsx
+++ b/components/verse-view-tracker.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+import { useEffect } from "react"
+
+export function VerseViewTracker({ verseId }: { verseId: string }) {
+  useEffect(() => {
+    fetch("/api/verse-views", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ verseId }),
+    })
+  }, [verseId])
+  return null
+}

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -109,6 +109,15 @@ export const comments = pgTable("comments", {
   updatedAt: timestamp("updated_at").notNull(),
 })
 
+// Verse views table
+export const verseViews = pgTable("verse_views", {
+  id: text("id").primaryKey(),
+  userId: text("user_id").references(() => users.id),
+  verseId: text("verse_id").notNull().references(() => verses.id),
+  translationId: text("translation_id").references(() => translations.id),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+})
+
 // Session table
 export const sessions = pgTable("sessions", {
   id: text("id").primaryKey(),
@@ -130,6 +139,7 @@ export const versesRelations = relations(verses, ({ one, many }) => ({
   translations: many(translations),
   notes: many(notes),
   comments: many(comments),
+  verseViews: many(verseViews),
 }))
 
 export const translationsRelations = relations(translations, ({ one, many }) => ({
@@ -138,6 +148,7 @@ export const translationsRelations = relations(translations, ({ one, many }) => 
     references: [verses.id],
   }),
   wordMappings: many(wordMappings),
+  verseViews: many(verseViews),
 }))
 
 export const usersRelations = relations(users, ({ many }) => ({
@@ -145,6 +156,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   notes: many(notes),
   comments: many(comments),
   sessions: many(sessions),
+  verseViews: many(verseViews),
 }))
 
 export const favoritesRelations = relations(favorites, ({ one }) => ({
@@ -177,6 +189,21 @@ export const commentsRelations = relations(comments, ({ one }) => ({
   verse: one(verses, {
     fields: [comments.verseId],
     references: [verses.id],
+  }),
+}))
+
+export const verseViewsRelations = relations(verseViews, ({ one }) => ({
+  user: one(users, {
+    fields: [verseViews.userId],
+    references: [users.id],
+  }),
+  verse: one(verses, {
+    fields: [verseViews.verseId],
+    references: [verses.id],
+  }),
+  translation: one(translations, {
+    fields: [verseViews.translationId],
+    references: [translations.id],
   }),
 }))
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -109,6 +109,17 @@ model Comment {
   updatedAt DateTime @updatedAt
 }
 
+model VerseView {
+  id            String        @id @default(cuid())
+  userId        String?
+  user          User?         @relation(fields: [userId], references: [id])
+  verseId       String
+  verse         Verse         @relation(fields: [verseId], references: [id])
+  translationId String?
+  translation   Translation?  @relation(fields: [translationId], references: [id])
+  createdAt     DateTime      @default(now())
+}
+
 model Session {
   id        String   @id @default(cuid())
   userId    String


### PR DESCRIPTION
## Summary
- track verse views and translation selections in new database table
- expose contributor leaderboard and personal dashboard pages
- log verse views via API and client-side components

## Testing
- `pnpm test`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*


------
https://chatgpt.com/codex/tasks/task_e_689477d1bd648323a9139a39e17ae0e8