### PR TITLE
feat: add API endpoints for content and data export

### DIFF
--- a/app/api/translations/import.ts
+++ b/app/api/translations/import.ts
@@ -4,14 +4,49 @@ import { translations } from "@/lib/schema"
 import { v4 as uuidv4 } from "uuid"
 
 function parseCSV(text: string) {
+  const parseLine = (line: string) => {
+    const result: string[] = []
+    let current = ""
+    let inQuotes = false
+    for (let i = 0; i < line.length; i++) {
+      const char = line[i]
+      if (char === '"') {
+        if (inQuotes && line[i + 1] === '"') {
+          current += '"'
+          i++
+        } else {
+          inQuotes = !inQuotes
+        }
+      } else if (char === "," && !inQuotes) {
+        result.push(current.trim())
+        current = ""
+      } else {
+        current += char
+      }
+    }
+    result.push(current.trim())
+    return result
+  }
+
   const [headerLine, ...lines] = text.trim().split(/\r?\n/)
-  const headers = headerLine.split(",").map((h) => h.trim())
-  return lines.filter(Boolean).map((line) => {
-    const values = line.split(",")
-    const record: Record<string, string> = {}
-    headers.forEach((h, i) => (record[h] = values[i]?.trim() ?? ""))
-    return record
-  })
+  const headers = parseLine(headerLine)
+
+  const records: Record<string, string>[] = []
+  for (const line of lines) {
+    if (!line) continue
+    let values = parseLine(line)
+    if (values.length > headers.length) {
+      values = values.slice(0, headers.length)
+    } else if (values.length < headers.length) {
+      while (values.length < headers.length) values.push("")
+    }
+    if (values.length === headers.length) {
+      const record: Record<string, string> = {}
+      headers.forEach((h, i) => (record[h] = values[i]))
+      records.push(record)
+    }
+  }
+  return records
 }
 
 export async function POST(req: Request) {

--- a/app/api/translations/import.ts
+++ b/app/api/translations/import.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { translations } from "@/lib/schema"
+import { v4 as uuidv4 } from "uuid"
+
+function parseCSV(text: string) {
+  const [headerLine, ...lines] = text.trim().split(/\r?\n/)
+  const headers = headerLine.split(",").map((h) => h.trim())
+  return lines.filter(Boolean).map((line) => {
+    const values = line.split(",")
+    const record: Record<string, string> = {}
+    headers.forEach((h, i) => (record[h] = values[i]?.trim() ?? ""))
+    return record
+  })
+}
+
+export async function POST(req: Request) {
+  const formData = await req.formData()
+  const file = formData.get("file") as File | null
+  if (!file) {
+    return NextResponse.json({ error: "No file provided" }, { status: 400 })
+  }
+  const content = await file.text()
+  let records: any[] = []
+  try {
+    if (file.type === "application/json" || file.name.endsWith(".json")) {
+      records = JSON.parse(content)
+    } else {
+      records = parseCSV(content)
+    }
+  } catch {
+    return NextResponse.json({ error: "Invalid file format" }, { status: 400 })
+  }
+  let count = 0
+  for (const r of records) {
+    if (!r.text || !r.translator || !r.verseId) continue
+    try {
+      await db.insert(translations).values({
+        id: uuidv4(),
+        text: r.text,
+        translator: r.translator,
+        verseId: r.verseId,
+        language: r.language || "English",
+        updatedAt: new Date(),
+      })
+      count++
+    } catch {
+      // ignore individual insert errors
+    }
+  }
+  return NextResponse.json({ imported: count })
+}

--- a/app/api/users/[id]/export.ts
+++ b/app/api/users/[id]/export.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { eq } from "drizzle-orm"
+
+function toCSV(data: Record<string, any>) {
+  const keys = Object.keys(data)
+  const values = keys.map((k) => JSON.stringify(data[k] ?? ""))
+  return keys.join(",") + "\n" + values.join(",")
+}
+
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  const { id } = params
+  const format = new URL(req.url).searchParams.get("format") || "json"
+  try {
+    const user = await db.query.users.findFirst({
+      where: (u, { eq }) => eq(u.id, id),
+    })
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 })
+    }
+    if (format === "csv") {
+      return new NextResponse(toCSV(user), {
+        headers: { "Content-Type": "text/csv" },
+      })
+    }
+    return NextResponse.json(user)
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Failed to export user data" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/v1/books/route.ts
+++ b/app/api/v1/books/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server"
+import { translations } from "@/lib/translations"
+
+const books = Object.entries(translations).map(([id, book]) => ({
+  id,
+  title: book.title,
+  description: book.description,
+}))
+
+export async function GET() {
+  return NextResponse.json(books)
+}

--- a/app/api/v1/translations/route.ts
+++ b/app/api/v1/translations/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server"
+import { translations } from "@/lib/translations"
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const verseId = searchParams.get("verseId")
+  const book = translations.xinxinming
+  if (verseId) {
+    const verse = book.verses.find((v) => v.id === Number(verseId))
+    if (!verse) {
+      return NextResponse.json({ error: "Verse not found" }, { status: 404 })
+    }
+    const list = verse.lines.flatMap((line) =>
+      Object.entries(line.translations).map(([translator, text]) => ({
+        translator,
+        text,
+      }))
+    )
+    return NextResponse.json(list)
+  }
+  return NextResponse.json(book.translators)
+}

--- a/app/api/v1/verses/route.ts
+++ b/app/api/v1/verses/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server"
+import { translations } from "@/lib/translations"
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const bookId = searchParams.get("book") || "xinxinming"
+  const book = (translations as Record<string, any>)[bookId]
+  if (!book) {
+    return NextResponse.json({ error: "Book not found" }, { status: 404 })
+  }
+  return NextResponse.json(book.verses)
+}


### PR DESCRIPTION
## Summary
- expose book, verse, and translation data under `/api/v1`
- add user export endpoint supporting JSON and CSV
- enable bulk translation import via upload

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689477d3a9c48323b891dd24dcc7254e