### PR TITLE
Add share links, social metadata, and sitemap generation

### DIFF
--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server"
+
+export async function POST(req: Request) {
+  const { bookId, verseId, highlight } = await req.json()
+
+  if (!bookId || !verseId || !highlight) {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 })
+  }
+
+  const url = new URL(req.url)
+  const baseUrl = `${url.protocol}//${url.host}`
+  const shareUrl = `${baseUrl}/books/${bookId}/verses/${verseId}?highlight=${encodeURIComponent(highlight)}`
+
+  return NextResponse.json({ url: shareUrl })
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,29 @@ const inter = Inter({ subsets: ["latin"] })
 export const metadata: Metadata = {
   title: "Zen Texts Translation Comparison",
   description: "Compare different translations of classic Zen texts",
-    generator: 'v0.dev'
+  generator: "v0.dev",
+  openGraph: {
+    title: "Zen Texts Translation Comparison",
+    description: "Compare different translations of classic Zen texts",
+    url: "https://v0-compare-translation-apps.vercel.app",
+    siteName: "Zen Texts Translation Comparison",
+    images: [
+      {
+        url: "/xinxin-ming-cover.png",
+        width: 1200,
+        height: 630,
+        alt: "Zen Texts Translation Comparison",
+      },
+    ],
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Zen Texts Translation Comparison",
+    description: "Compare different translations of classic Zen texts",
+    images: ["/xinxin-ming-cover.png"],
+  },
 }
 
 export default function RootLayout({

--- a/package.json
+++ b/package.json
@@ -3,11 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "next build",
+    "build": "next build && node scripts/generate-sitemap.js",
     "dev": "next dev",
     "lint": "next lint",
     "start": "next start",
-    "test": "vitest run"
+    "test": "vitest run",
+    "sitemap": "node scripts/generate-sitemap.js"
   },
   "dependencies": {
     "@aws-sdk/client-rds-data": "latest",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://v0-compare-translation-apps.vercel.app/about</loc></url>
+  <url><loc>https://v0-compare-translation-apps.vercel.app/books</loc></url>
+  <url><loc>https://v0-compare-translation-apps.vercel.app/compare</loc></url>
+  <url><loc>https://v0-compare-translation-apps.vercel.app/</loc></url>
+  <url><loc>https://v0-compare-translation-apps.vercel.app/pdf-preview</loc></url>
+  <url><loc>https://v0-compare-translation-apps.vercel.app/translations</loc></url>
+</urlset>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,0 +1,32 @@
+const fs = require('fs')
+const path = require('path')
+
+const baseUrl = process.env.SITE_URL || 'https://v0-compare-translation-apps.vercel.app'
+
+function getRoutes(dir, route = '') {
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  let routes = []
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('_') || entry.name.startsWith('.')) continue
+    const res = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name.startsWith('(')) continue
+      if (entry.name.includes('[')) continue
+      routes = routes.concat(getRoutes(res, `${route}/${entry.name}`))
+    } else if (entry.name === 'page.tsx' || entry.name === 'page.js' || entry.name === 'page.ts') {
+      routes.push(route === '' ? '/' : route)
+    }
+  }
+
+  return routes
+}
+
+const pagesDir = path.join(process.cwd(), 'app')
+const routes = Array.from(new Set(getRoutes(pagesDir)))
+
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${routes
+  .map((route) => `  <url><loc>${baseUrl}${route}</loc></url>`)
+  .join('\n')}\n</urlset>\n`
+
+fs.writeFileSync(path.join(process.cwd(), 'public', 'sitemap.xml'), sitemap)

--- a/tests/share.test.ts
+++ b/tests/share.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { POST } from '../app/api/share/route'
+
+const baseUrl = 'https://example.com'
+
+function createRequest(body: Record<string, unknown>) {
+  return new Request(`${baseUrl}/api/share`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body)
+  })
+}
+
+describe('POST /api/share', () => {
+  it('returns a share URL for valid input', async () => {
+    const req = createRequest({
+      bookId: 'john',
+      verseId: '3-16',
+      highlight: 'For God so loved the world'
+    })
+
+    const res = await POST(req)
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data.url).toBe(
+      `${baseUrl}/books/john/verses/3-16?highlight=${encodeURIComponent(
+        'For God so loved the world'
+      )}`
+    )
+  })
+
+  it('returns 400 when required fields are missing', async () => {
+    const req = createRequest({ bookId: 'john' })
+    const res = await POST(req)
+    const data = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(data.error).toBe('Missing fields')
+  })
+})


### PR DESCRIPTION
## Summary
- enrich root layout with OpenGraph and Twitter metadata
- add API endpoint to generate shareable highlight URLs
- generate sitemap via build script and include result

## Testing
- `pnpm test`
- `pnpm build` *(fails: Module not found: Can't resolve 'next-themes')*


------
https://chatgpt.com/codex/tasks/task_e_689477d85cfc8323ac04cde47a6a1f0e