### PR TITLE
Add quote API, zen mode styles, and comment timer

### DIFF
--- a/app/api/quotes/route.ts
+++ b/app/api/quotes/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server"
+import { promises as fs } from "fs"
+import path from "path"
+
+interface Quote {
+  text: string
+  author?: string
+}
+
+const QUOTES_FILE = path.join(process.cwd(), "data", "quotes.json")
+
+export const revalidate = 86400 // revalidate once per day
+
+async function getLocalQuote(): Promise<Quote> {
+  try {
+    const raw = await fs.readFile(QUOTES_FILE, "utf8")
+    const quotes: Quote[] = JSON.parse(raw)
+    return quotes[Math.floor(Math.random() * quotes.length)]
+  } catch {
+    return { text: "Be present. The rest will follow." }
+  }
+}
+
+export async function GET() {
+  try {
+    const res = await fetch(
+      "https://www.reddit.com/r/quotes/top.json?limit=50&t=day",
+      { next: { revalidate: 86400 } }
+    )
+    const json = await res.json()
+    const posts = json?.data?.children
+    if (Array.isArray(posts) && posts.length) {
+      const post = posts[Math.floor(Math.random() * posts.length)].data
+      if (post?.title) {
+        return NextResponse.json({ text: post.title })
+      }
+    }
+  } catch {
+    // ignore errors and fall back to local quotes
+  }
+  const quote = await getLocalQuote()
+  return NextResponse.json(quote)
+}

--- a/components/comment-timer.tsx
+++ b/components/comment-timer.tsx
@@ -1,0 +1,32 @@
+"use client"
+import { useEffect, useState } from "react"
+
+interface CommentTimerProps {
+  seconds?: number
+  onComplete?: () => void
+}
+
+export function CommentTimer({ seconds = 5, onComplete }: CommentTimerProps) {
+  const [remaining, setRemaining] = useState(seconds)
+
+  useEffect(() => {
+    setRemaining(seconds)
+    const timer = setInterval(() => {
+      setRemaining((prev) => {
+        if (prev <= 1) {
+          clearInterval(timer)
+          onComplete?.()
+          return 0
+        }
+        return prev - 1
+      })
+    }, 1000)
+    return () => clearInterval(timer)
+  }, [seconds, onComplete])
+
+  return (
+    <div className="text-center text-sm text-muted-foreground">
+      {remaining > 0 ? `Take a breath… ${remaining}s` : "Mindful moment complete"}
+    </div>
+  )
+}

--- a/data/quotes.json
+++ b/data/quotes.json
@@ -1,0 +1,5 @@
+[
+  { "text": "Wherever you go, there you are.", "author": "Confucius" },
+  { "text": "To a mind that is still, the whole universe surrenders.", "author": "Lao Tzu" },
+  { "text": "Peace comes from within. Do not seek it without.", "author": "Buddha" }
+]

--- a/styles/zen-mode.css
+++ b/styles/zen-mode.css
@@ -1,0 +1,19 @@
+/* Minimalist Zen Mode stylesheet */
+body.zen-mode {
+  background-color: #fdfdf9;
+  color: #222;
+  font-family: serif;
+}
+
+body.zen-mode header,
+body.zen-mode nav,
+body.zen-mode footer,
+body.zen-mode aside {
+  display: none;
+}
+
+body.zen-mode main {
+  max-width: 60ch;
+  margin: 0 auto;
+  padding: 2rem;
+}


### PR DESCRIPTION
## Summary
- fetch daily quotes from Reddit with local fallback and caching
- add minimalist Zen Mode stylesheet
- create mindful comment timer component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689477d9a3b48323ab59b15cb6d05dbc