### PR TITLE
feat: add realtime transport evaluation and audio player

### DIFF
--- a/components/audio-player.tsx
+++ b/components/audio-player.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+
+interface AudioPlayerProps {
+  text?: string
+  src?: string
+}
+
+export function AudioPlayer({ text, src }: AudioPlayerProps) {
+  const audioRef = useRef<HTMLAudioElement>(null)
+  const [speaking, setSpeaking] = useState(false)
+
+  function speak() {
+    if (!text || typeof window === "undefined") return
+    const utterance = new SpeechSynthesisUtterance(text)
+    utterance.onend = () => setSpeaking(false)
+    setSpeaking(true)
+    window.speechSynthesis.speak(utterance)
+  }
+
+  useEffect(() => {
+    return () => {
+      if (typeof window !== "undefined") window.speechSynthesis.cancel()
+    }
+  }, [])
+
+  return (
+    <div className="flex items-center gap-2">
+      {src && <audio ref={audioRef} controls src={src} className="h-8" />}
+      {text && (
+        <button
+          onClick={speak}
+          disabled={speaking}
+          className="text-sm px-2 py-1 border rounded"
+        >
+          {speaking ? "Speaking..." : "Speak"}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/lib/realtime.ts
+++ b/lib/realtime.ts
@@ -1,0 +1,42 @@
+/**
+ * Provides a thin abstraction for delivering real-time verse annotations.
+ *
+ * WebSocket
+ *   + Simple server implementation
+ *   + Works in both browser and Node environments
+ *   - Requires a central server for relay
+ *
+ * WebRTC
+ *   + Peer-to-peer with potential for lower latency and bandwidth
+ *   - Requires additional signalling infrastructure
+ *   - Browser-only APIs and more complex to debug
+ *
+ * The current default uses WebSocket, while keeping a placeholder for WebRTC
+ * should future development favour a peer-to-peer model.
+ */
+
+export type RealtimeTransport = "websocket" | "webrtc"
+
+export interface RealtimeChannel {
+  send: (data: string) => void
+  close: () => void
+}
+
+export function createRealtime(
+  url: string,
+  transport: RealtimeTransport = "websocket"
+): RealtimeChannel {
+  if (transport === "webrtc") {
+    // Full WebRTC implementation would require signalling; not provided yet.
+    console.warn("WebRTC not implemented. Falling back to WebSocket.")
+  }
+
+  const ws = new WebSocket(url)
+
+  return {
+    send: (data: string) => {
+      if (ws.readyState === WebSocket.OPEN) ws.send(data)
+    },
+    close: () => ws.close()
+  }
+}


### PR DESCRIPTION
## Summary
- add WebSocket-focused realtime helper with placeholders for WebRTC
- add audio player component with optional text-to-speech

## Testing
- `pnpm test`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689477da59948323bbfc135dab6112a9