### PR TITLE
feat: add multi-verse comparison page

### DIFF
--- a/app/compare/multi/page.test.tsx
+++ b/app/compare/multi/page.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+
+const { booksFindMany, versesFindMany } = vi.hoisted(() => ({
+  booksFindMany: vi.fn(),
+  versesFindMany: vi.fn(),
+}));
+
+vi.mock('@radix-ui/react-slot', () => ({
+  Slot: ({ children }: any) => <>{children}</>,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    query: {
+      books: { findMany: booksFindMany },
+      verses: { findMany: versesFindMany },
+    },
+  },
+}));
+
+import MultiComparePage from './page';
+
+const booksData = [
+  {
+    id: 'book1',
+    title: 'Book One',
+    verses: [{ id: 'v1', number: 1 }],
+  },
+  {
+    id: 'book2',
+    title: 'Book Two',
+    verses: [{ id: 'v2', number: 2 }],
+  },
+];
+
+describe('MultiComparePage', () => {
+  beforeEach(() => {
+    booksFindMany.mockResolvedValue(booksData);
+    booksFindMany.mockClear();
+    versesFindMany.mockClear();
+  });
+
+  it('displays translations for selected verses', async () => {
+    versesFindMany.mockResolvedValue([
+      {
+        id: 'v1',
+        number: 1,
+        bookId: 'book1',
+        book: { id: 'book1', title: 'Book One' },
+        translations: [
+          { id: 't1', translator: 'Alice', text: 'Text 1' },
+        ],
+      },
+      {
+        id: 'v2',
+        number: 2,
+        bookId: 'book2',
+        book: { id: 'book2', title: 'Book Two' },
+        translations: [
+          { id: 't2', translator: 'Bob', text: 'Text 2' },
+        ],
+      },
+    ]);
+
+    const jsx = await MultiComparePage({ searchParams: { ids: ['v1', 'v2'] } });
+    const html = renderToString(jsx);
+
+    expect(html).toContain('Book One<!-- --> - Verse <!-- -->1');
+    expect(html).toContain('Alice');
+    expect(html).toContain('Text 1');
+    expect(html).toContain('Book Two<!-- --> - Verse <!-- -->2');
+    expect(html).toContain('Bob');
+    expect(html).toContain('Text 2');
+  });
+
+  it('handles empty selection', async () => {
+    const jsx = await MultiComparePage({ searchParams: {} });
+    const html = renderToString(jsx);
+
+    expect(versesFindMany).not.toHaveBeenCalled();
+    expect(html).not.toContain('Book One<!-- --> - Verse <!-- -->1');
+    expect(html).not.toContain('Book Two<!-- --> - Verse <!-- -->2');
+  });
+
+  it('handles invalid ids', async () => {
+    versesFindMany.mockResolvedValue([]);
+
+    const jsx = await MultiComparePage({ searchParams: { ids: ['bad'] } });
+    const html = renderToString(jsx);
+
+    expect(versesFindMany).toHaveBeenCalled();
+    expect(html).not.toContain('Book One<!-- --> - Verse <!-- -->1');
+    expect(html).not.toContain('Book Two<!-- --> - Verse <!-- -->2');
+  });
+});
+

--- a/app/compare/multi/page.tsx
+++ b/app/compare/multi/page.tsx
@@ -1,0 +1,92 @@
+import { db } from "@/lib/db"
+import { verses } from "@/lib/schema"
+import { inArray, asc } from "drizzle-orm"
+import { Button } from "@/components/ui/button"
+import { Card } from "@/components/ui/card"
+
+export default async function MultiComparePage({
+  searchParams,
+}: {
+  searchParams: { ids?: string | string[] }
+}) {
+  // Fetch all books with their verses for the selection UI
+  const allBooks = await db.query.books.findMany({
+    with: {
+      verses: {
+        orderBy: (v, { asc }) => [asc(v.number)],
+      },
+    },
+  })
+
+  // Normalize the ids search param into an array
+  const idsParam = searchParams?.ids
+  const verseIds = Array.isArray(idsParam)
+    ? idsParam
+    : idsParam
+    ? [idsParam]
+    : []
+
+  // Fetch selected verses with their translations
+  const selectedVerses = verseIds.length
+    ? await db.query.verses.findMany({
+        where: inArray(verses.id, verseIds),
+        with: {
+          book: true,
+          translations: {
+            orderBy: (t, { asc }) => [asc(t.translator)],
+          },
+        },
+        orderBy: (v, { asc }) => [asc(v.bookId), asc(v.number)],
+      })
+    : []
+
+  return (
+    <main className="flex min-h-screen flex-col items-center p-4 md:p-24">
+      <div className="max-w-4xl w-full">
+        <h1 className="text-3xl font-bold mb-6">Compare Multiple Verses</h1>
+
+        <Card className="p-6 mb-8">
+          <form className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-2">Select Verses</label>
+              <select
+                name="ids"
+                multiple
+                size={10}
+                defaultValue={verseIds}
+                className="w-full border rounded p-2 h-48"
+              >
+                {allBooks.map((book) => (
+                  <optgroup key={book.id} label={book.title}>
+                    {book.verses.map((verse) => (
+                      <option key={verse.id} value={verse.id}>
+                        Verse {verse.number}
+                      </option>
+                    ))}
+                  </optgroup>
+                ))}
+              </select>
+            </div>
+            <Button type="submit">Compare</Button>
+          </form>
+        </Card>
+
+        {selectedVerses.map((verse) => (
+          <Card key={verse.id} className="p-6 mb-4">
+            <h2 className="text-xl font-semibold mb-4">
+              {verse.book.title} - Verse {verse.number}
+            </h2>
+            <div className="space-y-4">
+              {verse.translations.map((t) => (
+                <div key={t.id} className="border-b pb-2 last:border-0 last:pb-0">
+                  <h3 className="font-medium">{t.translator}</h3>
+                  <p className="whitespace-pre-line">{t.text}</p>
+                </div>
+              ))}
+            </div>
+          </Card>
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './'),
+    },
+  },
+  esbuild: {
+    jsx: 'automatic',
+    jsxImportSource: 'react',
+  },
+});


### PR DESCRIPTION
## Summary
- add page to compare multiple verses across books
- support selection UI and grouped translation display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689477dd530c832387ad6414ee06e22d