### PR TITLE
Add daily quote API and zen mode tools

### DIFF
--- a/app/api/quotes/route.test.ts
+++ b/app/api/quotes/route.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { GET } from './route'
+import quotes from '../../../data/quotes.json'
+
+describe('GET /api/quotes', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2024-01-01'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('returns quote from Reddit when fetch succeeds', async () => {
+    vi.stubGlobal('fetch', () =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: { children: [{ data: { title: 'Reddit quote', author: 'user1' } }] }
+          }),
+          { status: 200 }
+        )
+      )
+    )
+
+    const res = await GET()
+    const data = await res.json()
+    expect(data).toEqual({ text: 'Reddit quote', author: 'user1' })
+  })
+
+  it('falls back to static quotes when Reddit fetch fails', async () => {
+    vi.stubGlobal('fetch', () => Promise.resolve(new Response('', { status: 500 })))
+
+    const res = await GET()
+    const data = await res.json()
+    const expected = (quotes as { text: string; author: string }[])[1]
+    expect(data).toEqual(expected)
+  })
+})

--- a/app/api/quotes/route.ts
+++ b/app/api/quotes/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import quotes from "@/data/quotes.json"
+import quotes from "../../../data/quotes.json"
 
 const SUBREDDIT = process.env.QUOTES_SUBREDDIT || "quotes"
 

--- a/app/api/quotes/route.ts
+++ b/app/api/quotes/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server"
+import quotes from "@/data/quotes.json"
+
+const SUBREDDIT = process.env.QUOTES_SUBREDDIT || "quotes"
+
+interface Quote {
+  text: string
+  author: string
+}
+
+function dayIndex(length: number): number {
+  const now = new Date()
+  const start = new Date(now.getFullYear(), 0, 0)
+  const diff = now.getTime() - start.getTime()
+  const oneDay = 1000 * 60 * 60 * 24
+  return Math.floor(diff / oneDay) % length
+}
+
+async function fetchRedditQuote(): Promise<Quote> {
+  const res = await fetch(`https://www.reddit.com/r/${SUBREDDIT}.json`, {
+    headers: { "User-Agent": "ZenMultiTranslation/1.0" }
+  })
+  if (!res.ok) {
+    throw new Error("Reddit fetch failed")
+  }
+  const json = await res.json()
+  const posts = (json.data?.children || []) as any[]
+  if (!posts.length) throw new Error("No posts")
+  const post = posts[dayIndex(posts.length)].data
+  return { text: post.title, author: post.author }
+}
+
+export async function GET() {
+  try {
+    const quote = await fetchRedditQuote()
+    return NextResponse.json(quote)
+  } catch (e) {
+    const fallback = (quotes as Quote[])[dayIndex((quotes as Quote[]).length)]
+    return NextResponse.json(fallback)
+  }
+}

--- a/components/comment-timer.tsx
+++ b/components/comment-timer.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+export function CommentTimer({
+  initialSeconds = 10,
+  onExpire
+}: {
+  initialSeconds?: number
+  onExpire?: () => void
+}) {
+  const [seconds, setSeconds] = useState(initialSeconds)
+
+  useEffect(() => {
+    if (seconds <= 0) {
+      onExpire?.()
+      return
+    }
+    const id = setTimeout(() => setSeconds((s) => s - 1), 1000)
+    return () => clearTimeout(id)
+  }, [seconds, onExpire])
+
+  return (
+    <div className="text-sm text-muted-foreground">
+      {seconds > 0
+        ? `Take a breath... ${seconds}s`
+        : "You may comment now."}
+    </div>
+  )
+}

--- a/data/quotes.json
+++ b/data/quotes.json
@@ -1,0 +1,5 @@
+[
+  { "text": "Be present in all things and thankful for all things.", "author": "Maya Angelou" },
+  { "text": "The quieter you become, the more you can hear.", "author": "Ram Dass" },
+  { "text": "Simplicity is the ultimate sophistication.", "author": "Leonardo da Vinci" }
+]

--- a/styles/zen-mode.css
+++ b/styles/zen-mode.css
@@ -1,0 +1,15 @@
+/* Minimalist zen mode styling */
+body.zen-mode {
+  background: #fdfdfc;
+  color: #222;
+  font-family: "Georgia", serif;
+  margin: 0;
+  padding: 2rem;
+}
+
+.zen-mode .app-container {
+  max-width: 60ch;
+  margin: 0 auto;
+  line-height: 1.6;
+  font-size: 1.1rem;
+}


### PR DESCRIPTION
## Summary
- add `/api/quotes` endpoint that retrieves a daily quote from Reddit with static JSON fallback
- introduce `zen-mode.css` for minimalist styling
- create `CommentTimer` component to encourage mindful commenting

## Testing
- `pnpm test`
- `pnpm lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68947c4116d883239e7339878f4d6eda