### PR TITLE
Add reddit and multi-book comparison tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "lint": "next lint",
     "start": "next start",
-    "test": "vitest run"
+    "test": "vitest run tests"
   },
   "dependencies": {
     "@aws-sdk/client-rds-data": "latest",

--- a/tests/multi-book-compare.test.ts
+++ b/tests/multi-book-compare.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+
+interface Translation { translator: string }
+interface Verse { translations: Translation[] }
+interface Book { id: string; verses: Verse[] }
+
+function seedBooks(): Book[] {
+  return [
+    {
+      id: 'book1',
+      verses: [
+        { translations: [{ translator: 'A' }, { translator: 'B' }] },
+      ],
+    },
+    {
+      id: 'book2',
+      verses: [
+        { translations: [{ translator: 'A' }, { translator: 'C' }] },
+        { translations: [{ translator: 'B' }] },
+      ],
+    },
+  ]
+}
+
+function aggregateBooks(books: Book[]) {
+  const totalBooks = books.length
+  const totalVerses = books.reduce((sum, b) => sum + b.verses.length, 0)
+  const translatorCount: Record<string, number> = {}
+  for (const book of books) {
+    for (const verse of book.verses) {
+      for (const tr of verse.translations) {
+        translatorCount[tr.translator] = (translatorCount[tr.translator] || 0) + 1
+      }
+    }
+  }
+  return { totalBooks, totalVerses, translatorCount }
+}
+
+describe('multi-book comparison', () => {
+  it('aggregates verses and translators across books', () => {
+    const books = seedBooks()
+    const result = aggregateBooks(books)
+    expect(result.totalBooks).toBe(2)
+    expect(result.totalVerses).toBe(3)
+    expect(result.translatorCount).toEqual({ A: 2, B: 2, C: 1 })
+  })
+})

--- a/tests/reddit-feed.test.ts
+++ b/tests/reddit-feed.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { GET } from '../app/api/reddit/route'
+
+describe('reddit api route', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns formatted posts from reddit', async () => {
+    const mockResponse = {
+      data: {
+        children: [
+          { data: { id: '1', title: 't1', author: 'a1', permalink: '/r/test1', ups: 10 } },
+          { data: { id: '2', title: 't2', author: 'a2', permalink: '/r/test2', ups: 5 } },
+        ],
+      },
+    }
+
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    } as any)
+
+    const req = new Request('http://localhost/api/reddit?subreddit=test')
+    const res = await GET(req)
+    const posts = await res.json()
+
+    expect(posts).toEqual([
+      { id: '1', title: 't1', author: 'a1', url: 'https://www.reddit.com/r/test1', upvotes: 10 },
+      { id: '2', title: 't2', author: 'a2', url: 'https://www.reddit.com/r/test2', upvotes: 5 },
+    ])
+  })
+
+  it('handles error response', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({ ok: false, status: 404 } as any)
+
+    const req = new Request('http://localhost/api/reddit?subreddit=test')
+    const res = await GET(req)
+    const body = await res.json()
+
+    expect(res.status).toBe(404)
+    expect(body.error).toBe('Failed to fetch posts')
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for reddit API route with mocked fetch
- check multi-book comparison aggregation logic
- run vitest over tests directory

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68947c45170083238a3f7b3360e9fb66