### PR TITLE
feat: add nested comments and moderation

### DIFF
--- a/app/api/comments/[id]/moderate.ts
+++ b/app/api/comments/[id]/moderate.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server"
+import { readData, writeData, Comment } from "../route"
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  if (req.headers.get("x-admin") !== "true") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 })
+  }
+
+  const { action } = await req.json()
+  if (action !== "remove" && action !== "flag") {
+    return NextResponse.json({ error: "Invalid action" }, { status: 400 })
+  }
+
+  const data = await readData()
+  let found: Comment | null = null
+
+  for (const verseId of Object.keys(data)) {
+    const list = data[verseId]
+    const idx = list.findIndex((c) => c.id === params.id)
+    if (idx !== -1) {
+      if (action === "remove") {
+        const removed = list.splice(idx, 1)[0]
+        data[verseId] = list.filter((c) => c.parentId !== params.id)
+        found = removed
+      } else {
+        list[idx].flagged = true
+        found = list[idx]
+      }
+      break
+    }
+  }
+
+  if (!found) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+
+  await writeData(data)
+  return NextResponse.json(found)
+}

--- a/app/api/comments/route.ts
+++ b/app/api/comments/route.ts
@@ -1,17 +1,20 @@
 import { NextResponse } from "next/server"
 import { promises as fs } from "fs"
 import path from "path"
+import { renderMarkdown } from "../../../lib/markdown"
 
 export interface Comment {
   id: string
   content: string
   createdAt: string
   votes: number
+  parentId?: string | null
+  flagged?: boolean
 }
 
 const COMMENTS_FILE = path.join(process.cwd(), "data", "comments.json")
 
-async function readData() {
+export async function readData() {
   try {
     const data = await fs.readFile(COMMENTS_FILE, "utf8")
     return JSON.parse(data || "{}")
@@ -20,7 +23,7 @@ async function readData() {
   }
 }
 
-async function writeData(data: Record<string, Comment[]>) {
+export async function writeData(data: Record<string, Comment[]>) {
   await fs.mkdir(path.dirname(COMMENTS_FILE), { recursive: true })
   await fs.writeFile(COMMENTS_FILE, JSON.stringify(data, null, 2))
 }
@@ -42,24 +45,34 @@ export function voteComment(
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url)
   const verseId = searchParams.get("verseId")
+  const parentId = searchParams.get("parentId")
   const data = await readData()
   if (verseId) {
-    return NextResponse.json(data[verseId] || [])
+    let list = data[verseId] || []
+    if (parentId !== null) {
+      list = list.filter((c) => c.parentId === parentId)
+    } else {
+      list = list.filter((c) => !c.parentId)
+    }
+    return NextResponse.json(list)
   }
   return NextResponse.json(data)
 }
 
 export async function POST(req: Request) {
-  const { verseId, content } = await req.json()
+  const { verseId, content, parentId } = await req.json()
   if (!verseId || !content) {
     return NextResponse.json({ error: "Missing fields" }, { status: 400 })
   }
+  const sanitized = renderMarkdown(content)
   const data = await readData()
   const comment: Comment = {
     id: crypto.randomUUID(),
-    content,
+    content: sanitized,
     createdAt: new Date().toISOString(),
     votes: 0,
+    parentId: parentId ?? null,
+    flagged: false,
   }
   if (!data[verseId]) data[verseId] = []
   data[verseId].push(comment)

--- a/components/comment-form.tsx
+++ b/components/comment-form.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { useState, FormEvent } from "react"
+import { Button } from "@/components/ui/button"
+import { renderMarkdown } from "../lib/markdown"
+
+interface Props {
+  verseId: string
+  parentId?: string
+  onSubmitted?: () => void
+}
+
+export function CommentForm({ verseId, parentId, onSubmitted }: Props) {
+  const [content, setContent] = useState("")
+
+  async function submit(e: FormEvent) {
+    e.preventDefault()
+    if (!content.trim()) return
+    await fetch("/api/comments", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ verseId, content, parentId })
+    })
+    setContent("")
+    onSubmitted?.()
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-2">
+      <textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        placeholder="Write your comment in Markdown"
+        className="w-full border rounded p-2 text-sm"
+      />
+      {content && (
+        <div
+          className="p-2 border rounded text-sm bg-background"
+          dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }}
+        />
+      )}
+      <Button type="submit" size="sm">Post</Button>
+    </form>
+  )
+}

--- a/components/comment-section.tsx
+++ b/components/comment-section.tsx
@@ -1,17 +1,18 @@
 "use client"
-import { useEffect, useState, FormEvent } from "react"
-import { Button } from "@/components/ui/button"
+import { useEffect, useState } from "react"
+import { CommentForm } from "./comment-form"
 
 interface Comment {
   id: string
   content: string
   createdAt: string
   votes: number
+  parentId?: string | null
+  flagged?: boolean
 }
 
 export function CommentSection({ verseId }: { verseId: string }) {
   const [comments, setComments] = useState<Comment[]>([])
-  const [content, setContent] = useState("")
 
   async function load() {
     const res = await fetch(`/api/comments?verseId=${verseId}`)
@@ -21,18 +22,6 @@ export function CommentSection({ verseId }: { verseId: string }) {
   useEffect(() => {
     load()
   }, [verseId])
-
-  async function submit(e: FormEvent) {
-    e.preventDefault()
-    if (!content.trim()) return
-    await fetch("/api/comments", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ verseId, content })
-    })
-    setContent("")
-    load()
-  }
 
   async function vote(id: string, delta: number) {
     await fetch("/api/comments", {
@@ -46,20 +35,15 @@ export function CommentSection({ verseId }: { verseId: string }) {
   return (
     <div className="mt-8">
       <h3 className="text-lg font-semibold mb-2">Comments</h3>
-      <form onSubmit={submit} className="flex gap-2 mb-4">
-        <input
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-          placeholder="Add a comment"
-          className="flex-1 border rounded p-2 text-sm"
-        />
-        <Button type="submit" size="sm">Post</Button>
-      </form>
+      <CommentForm verseId={verseId} onSubmitted={load} />
       <div className="space-y-2">
         {comments.map((c) => (
           <div key={c.id} className="p-2 bg-muted rounded">
             <div className="flex items-center justify-between">
-              <div className="text-sm flex-1">{c.content}</div>
+              <div
+                className="text-sm flex-1"
+                dangerouslySetInnerHTML={{ __html: c.content }}
+              />
               <div className="flex items-center gap-1 ml-2">
                 <button
                   aria-label="upvote"

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -1,0 +1,10 @@
+export function renderMarkdown(md: string): string {
+  const escaped = md
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+  return escaped
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*(.+?)\*/g, "<em>$1</em>")
+    .replace(/\n/g, "<br />")
+}


### PR DESCRIPTION
## Summary
- support nested replies and markdown sanitization in comment API
- add markdown comment form with preview
- add admin moderation endpoint to flag or remove comments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68947c33a5ac8323bad5cf2457e0ba71