### PR TITLE
feat: add highlights support

### DIFF
--- a/app/api/highlights/route.ts
+++ b/app/api/highlights/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { highlights } from "@/lib/schema"
+import { eq, and } from "drizzle-orm"
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const verseId = searchParams.get("verseId")
+  const userId = searchParams.get("userId")
+
+  if (verseId && userId) {
+    const data = await db
+      .select()
+      .from(highlights)
+      .where(and(eq(highlights.verseId, verseId), eq(highlights.userId, userId)))
+    return NextResponse.json(data)
+  }
+
+  if (verseId) {
+    const data = await db
+      .select()
+      .from(highlights)
+      .where(and(eq(highlights.verseId, verseId), eq(highlights.isPublic, true)))
+    return NextResponse.json(data)
+  }
+
+  const data = await db
+    .select()
+    .from(highlights)
+    .where(eq(highlights.isPublic, true))
+  return NextResponse.json(data)
+}
+
+export async function POST(req: Request) {
+  const { verseId, start, end, isPublic = true, userId } = await req.json()
+  if (!verseId || typeof start !== "number" || typeof end !== "number" || !userId) {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 })
+  }
+  const [highlight] = await db
+    .insert(highlights)
+    .values({
+      id: crypto.randomUUID(),
+      verseId,
+      userId,
+      start,
+      end,
+      isPublic,
+      updatedAt: new Date(),
+    })
+    .returning()
+  return NextResponse.json(highlight)
+}

--- a/components/verse-viewer.tsx
+++ b/components/verse-viewer.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { useState } from "react"
+
+interface VerseViewerProps {
+  verseId: string
+  text: string
+  userId: string
+}
+
+export default function VerseViewer({ verseId, text, userId }: VerseViewerProps) {
+  const [range, setRange] = useState<
+    | { start: number; end: number; text: string }
+    | null
+  >(null)
+
+  function handleMouseUp() {
+    const sel = window.getSelection()
+    if (!sel || sel.rangeCount === 0) {
+      setRange(null)
+      return
+    }
+    const r = sel.getRangeAt(0)
+    if (r.collapsed) {
+      setRange(null)
+      return
+    }
+    const start = r.startOffset
+    const end = r.endOffset
+    setRange({ start, end, text: sel.toString() })
+  }
+
+  async function saveHighlight(isPublic: boolean) {
+    if (!range) return
+    await fetch("/api/highlights", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        verseId,
+        start: range.start,
+        end: range.end,
+        isPublic,
+        userId,
+      }),
+    })
+    setRange(null)
+  }
+
+  async function saveNote() {
+    if (!range) return
+    await fetch("/api/notes", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ verseId, content: range.text, userId }),
+    })
+    setRange(null)
+  }
+
+  return (
+    <div onMouseUp={handleMouseUp} className="select-text">
+      <p>{text}</p>
+      {range && (
+        <div className="mt-2 flex gap-2">
+          <button onClick={() => saveHighlight(true)}>Highlight Public</button>
+          <button onClick={() => saveHighlight(false)}>
+            Highlight Private
+          </button>
+          <button onClick={saveNote}>Save Note</button>
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -95,6 +95,22 @@ export const notes = pgTable("notes", {
   updatedAt: timestamp("updated_at").notNull(),
 })
 
+// Highlight table
+export const highlights = pgTable("highlights", {
+  id: text("id").primaryKey(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id),
+  verseId: text("verse_id")
+    .notNull()
+    .references(() => verses.id),
+  start: integer("start").notNull(),
+  end: integer("end").notNull(),
+  isPublic: boolean("is_public").default(true).notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").notNull(),
+})
+
 // Comment table
 export const comments = pgTable("comments", {
   id: text("id").primaryKey(),
@@ -130,6 +146,7 @@ export const versesRelations = relations(verses, ({ one, many }) => ({
   translations: many(translations),
   notes: many(notes),
   comments: many(comments),
+  highlights: many(highlights),
 }))
 
 export const translationsRelations = relations(translations, ({ one, many }) => ({
@@ -144,6 +161,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   favorites: many(favorites),
   notes: many(notes),
   comments: many(comments),
+  highlights: many(highlights),
   sessions: many(sessions),
 }))
 
@@ -176,6 +194,17 @@ export const commentsRelations = relations(comments, ({ one }) => ({
   }),
   verse: one(verses, {
     fields: [comments.verseId],
+    references: [verses.id],
+  }),
+}))
+
+export const highlightsRelations = relations(highlights, ({ one }) => ({
+  user: one(users, {
+    fields: [highlights.userId],
+    references: [users.id],
+  }),
+  verse: one(verses, {
+    fields: [highlights.verseId],
     references: [verses.id],
   }),
 }))


### PR DESCRIPTION
## Summary
- add highlights table with start/end positions
- allow verse viewer to select text and save highlights or notes
- create highlights API with public/private toggles

## Testing
- `pnpm test`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68947c349cc88323b5cb8848c10a0626