### PR TITLE
Add admin route protection and moderation endpoints

### DIFF
--- a/app/api/comments/[id]/delete.ts
+++ b/app/api/comments/[id]/delete.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server"
+import { promises as fs } from "fs"
+import path from "path"
+import { db } from "@/lib/db"
+import { auditLogs } from "@/lib/schema"
+
+const COMMENTS_FILE = path.join(process.cwd(), "data", "comments.json")
+
+async function readData() {
+  try {
+    const data = await fs.readFile(COMMENTS_FILE, "utf8")
+    return JSON.parse(data || "{}")
+  } catch {
+    return {}
+  }
+}
+
+async function writeData(data: Record<string, any>) {
+  await fs.mkdir(path.dirname(COMMENTS_FILE), { recursive: true })
+  await fs.writeFile(COMMENTS_FILE, JSON.stringify(data, null, 2))
+}
+
+function removeComment(data: Record<string, any>, commentId: string) {
+  for (const verseId of Object.keys(data)) {
+    const list = data[verseId]
+    const idx = list.findIndex((c: any) => c.id === commentId)
+    if (idx !== -1) {
+      list.splice(idx, 1)
+      return verseId
+    }
+  }
+  return null
+}
+
+export async function DELETE(req: Request, { params }: { params: { id: string } }) {
+  const data = await readData()
+  const verseId = removeComment(data, params.id)
+  if (!verseId) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+  await writeData(data)
+
+  const userId = req.headers.get("x-user-id") || undefined
+  await db.insert(auditLogs).values({
+    id: crypto.randomUUID(),
+    action: "delete_comment",
+    targetType: "comment",
+    targetId: params.id,
+    userId,
+  })
+
+  return NextResponse.json({ success: true })
+}

--- a/app/api/comments/[id]/flags.ts
+++ b/app/api/comments/[id]/flags.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { flags, auditLogs } from "@/lib/schema"
+import { eq } from "drizzle-orm"
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const { reason, userId } = await req.json()
+  const flagId = crypto.randomUUID()
+  await db.insert(flags).values({
+    id: flagId,
+    commentId: params.id,
+    userId,
+    reason,
+  })
+  await db.insert(auditLogs).values({
+    id: crypto.randomUUID(),
+    action: "flag_comment",
+    targetType: "comment",
+    targetId: params.id,
+    userId,
+  })
+  return NextResponse.json({ id: flagId })
+}
+
+export async function DELETE(req: Request, { params }: { params: { id: string } }) {
+  const { userId } = await req.json()
+  await db.delete(flags).where(eq(flags.commentId, params.id))
+  await db.insert(auditLogs).values({
+    id: crypto.randomUUID(),
+    action: "unflag_comment",
+    targetType: "comment",
+    targetId: params.id,
+    userId,
+  })
+  return NextResponse.json({ success: true })
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server"
+
+export function requireRole(req: NextRequest, role: string) {
+  const userRole = req.headers.get("x-user-role")
+  if (userRole !== role) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+  return NextResponse.next()
+}
+
+export function adminMiddleware(req: NextRequest) {
+  return requireRole(req, "admin")
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,10 @@
+import type { NextRequest } from "next/server"
+import { adminMiddleware } from "./lib/auth"
+
+export function middleware(req: NextRequest) {
+  return adminMiddleware(req)
+}
+
+export const config = {
+  matcher: ["/admin/:path*"],
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,12 +17,15 @@ model User {
   username  String   @unique
   password  String
   isGuest   Boolean  @default(false)
+  role      String   @default("user")
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-  
+
   favorites Favorite[]
   notes     Note[]
   comments  Comment[]
+  flags     Flag[]
+  auditLogs AuditLog[]
 }
 
 model Book {
@@ -107,6 +110,27 @@ model Comment {
   verse     Verse    @relation(fields: [verseId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+  flags     Flag[]
+}
+
+model Flag {
+  id        String   @id @default(cuid())
+  commentId String
+  comment   Comment  @relation(fields: [commentId], references: [id])
+  userId    String?
+  user      User?    @relation(fields: [userId], references: [id])
+  reason    String?
+  createdAt DateTime @default(now())
+}
+
+model AuditLog {
+  id         String   @id @default(cuid())
+  action     String
+  targetType String
+  targetId   String
+  userId     String?
+  user       User?    @relation(fields: [userId], references: [id])
+  createdAt  DateTime @default(now())
 }
 
 model Session {


### PR DESCRIPTION
## Summary
- implement role-based middleware and protect `/admin/*` routes
- add comment deletion and flagging endpoints that log moderation
- expand schema with user roles, flags, and audit logs tables

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68947c39601c8323b74145baf4b03ef0