### PR TITLE
Add REST API and user export/import endpoints

### DIFF
--- a/app/api/translations/import/route.ts
+++ b/app/api/translations/import/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { translations } from "@/lib/schema"
+
+export async function POST(req: Request) {
+  const form = await req.formData()
+  const file = form.get("file")
+  if (!file || typeof file === "string") {
+    return NextResponse.json({ error: "File is required" }, { status: 400 })
+  }
+  try {
+    const text = await (file as File).text()
+    const data = JSON.parse(text)
+    if (!Array.isArray(data)) {
+      return NextResponse.json({ error: "Invalid data" }, { status: 400 })
+    }
+    for (const item of data) {
+      if (!item.text || !item.translator || !item.verseId) continue
+      await db.insert(translations).values({
+        id: crypto.randomUUID(),
+        text: item.text,
+        translator: item.translator,
+        language: item.language || "English",
+        verseId: item.verseId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+    }
+    return NextResponse.json({ success: true, count: data.length })
+  } catch (e) {
+    return NextResponse.json({ error: "Failed to import" }, { status: 500 })
+  }
+}

--- a/app/api/users/[id]/export/route.ts
+++ b/app/api/users/[id]/export/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { users } from "@/lib/schema"
+import { eq } from "drizzle-orm"
+
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  const format = new URL(req.url).searchParams.get("format") || "json"
+  const user = await db.query.users.findFirst({
+    where: eq(users.id, params.id),
+    with: {
+      favorites: true,
+      notes: true,
+      comments: true,
+    },
+  })
+  if (!user) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+  if (format === "csv") {
+    let csv = `id,email,username\n${user.id},${user.email},${user.username}\n\n`
+    csv += "favorites\nid,bookId\n"
+    for (const f of user.favorites) {
+      csv += `${f.id},${f.bookId}\n`
+    }
+    csv += "\nnotes\nid,verseId,content\n"
+    for (const n of user.notes) {
+      csv += `${n.id},${n.verseId},"${n.content.replace(/"/g, '""')}"\n`
+    }
+    csv += "\ncomments\nid,verseId,content\n"
+    for (const c of user.comments) {
+      csv += `${c.id},${c.verseId},"${c.content.replace(/"/g, '""')}"\n`
+    }
+    return new Response(csv, {
+      headers: { "Content-Type": "text/csv" },
+    })
+  }
+  return NextResponse.json(user)
+}

--- a/app/api/v1/books/[id]/route.ts
+++ b/app/api/v1/books/[id]/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { books } from "@/lib/schema"
+import { eq } from "drizzle-orm"
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  const book = await db.query.books.findFirst({
+    where: eq(books.id, params.id),
+    with: {
+      verses: {
+        with: { translations: true },
+      },
+    },
+  })
+  if (!book) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+  return NextResponse.json(book)
+}

--- a/app/api/v1/books/route.ts
+++ b/app/api/v1/books/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { books } from "@/lib/schema"
+
+export async function GET() {
+  const allBooks = await db.select().from(books)
+  return NextResponse.json(allBooks)
+}
+
+export async function POST(req: Request) {
+  const { title, description, author, coverImage } = await req.json()
+  if (!title || !description) {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 })
+  }
+  const newBook = {
+    id: crypto.randomUUID(),
+    title,
+    description,
+    author,
+    coverImage,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }
+  await db.insert(books).values(newBook)
+  return NextResponse.json(newBook, { status: 201 })
+}

--- a/app/api/v1/translations/[id]/route.ts
+++ b/app/api/v1/translations/[id]/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { translations } from "@/lib/schema"
+import { eq } from "drizzle-orm"
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  const translation = await db.query.translations.findFirst({
+    where: eq(translations.id, params.id),
+  })
+  if (!translation) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+  return NextResponse.json(translation)
+}

--- a/app/api/v1/translations/route.ts
+++ b/app/api/v1/translations/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { translations } from "@/lib/schema"
+import { eq } from "drizzle-orm"
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const verseId = searchParams.get("verseId")
+  const result = verseId
+    ? await db.select().from(translations).where(eq(translations.verseId, verseId))
+    : await db.select().from(translations)
+  return NextResponse.json(result)
+}
+
+export async function POST(req: Request) {
+  const { text, translator, language, verseId } = await req.json()
+  if (!text || !translator || !verseId) {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 })
+  }
+  const newTranslation = {
+    id: crypto.randomUUID(),
+    text,
+    translator,
+    language: language || "English",
+    verseId,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }
+  await db.insert(translations).values(newTranslation)
+  return NextResponse.json(newTranslation, { status: 201 })
+}

--- a/app/api/v1/verses/[id]/route.ts
+++ b/app/api/v1/verses/[id]/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { verses } from "@/lib/schema"
+import { eq } from "drizzle-orm"
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  const verse = await db.query.verses.findFirst({
+    where: eq(verses.id, params.id),
+    with: { translations: true },
+  })
+  if (!verse) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+  return NextResponse.json(verse)
+}

--- a/app/api/v1/verses/route.ts
+++ b/app/api/v1/verses/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { verses } from "@/lib/schema"
+import { eq } from "drizzle-orm"
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const bookId = searchParams.get("bookId")
+  const result = bookId
+    ? await db.select().from(verses).where(eq(verses.bookId, bookId))
+    : await db.select().from(verses)
+  return NextResponse.json(result)
+}
+
+export async function POST(req: Request) {
+  const { number, bookId } = await req.json()
+  if (!number || !bookId) {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 })
+  }
+  const newVerse = {
+    id: crypto.randomUUID(),
+    number,
+    bookId,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }
+  await db.insert(verses).values(newVerse)
+  return NextResponse.json(newVerse, { status: 201 })
+}


### PR DESCRIPTION
## Summary
- add versioned REST API for books, verses, and translations
- provide user data export as JSON or CSV
- support translation import via file upload

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68947c3a56a08323aeb5953266263176