### PR TITLE
docs: add contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,9 @@ Continue building your app on:
 ## Environment Variables
 
 The Reddit integration uses Reddit's public JSON API and does not require authentication. To change the subreddit queried by the API route, define `REDDIT_SUBREDDIT` in your `.env` file. If you later switch to Reddit's authenticated API, you will also need to provide `REDDIT_CLIENT_ID` and `REDDIT_CLIENT_SECRET`.
+
+## Documentation
+
+- [Code of Conduct](docs/CODE_OF_CONDUCT.md)
+- [Contributing](docs/CONTRIBUTING.md)
+- [FAQ](docs/FAQ.md)

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter } from "next/font/google"
 import "./globals.css"
 import { Navigation } from "@/components/navigation"
 import { ThemeProvider } from "@/components/theme-provider"
+import { Footer } from "@/components/footer"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -24,6 +25,7 @@ export default function RootLayout({
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <Navigation />
           {children}
+          <Footer />
         </ThemeProvider>
       </body>
     </html>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link"
+
+export function Footer() {
+  return (
+    <footer className="border-t py-6 text-center text-sm">
+      <nav className="flex justify-center space-x-4">
+        <Link href="/docs/CODE_OF_CONDUCT.md" className="text-gray-600 hover:underline">
+          Code of Conduct
+        </Link>
+        <Link href="/docs/CONTRIBUTING.md" className="text-gray-600 hover:underline">
+          Contributing
+        </Link>
+        <Link href="/docs/FAQ.md" className="text-gray-600 hover:underline">
+          FAQ
+        </Link>
+      </nav>
+    </footer>
+  )
+}

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of Conduct
+
+We expect all participants to uphold the following guidelines:
+
+- Be respectful and considerate.
+- Use inclusive language.
+- Accept constructive criticism.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+Thank you for considering contributing to this project!
+
+## Getting Started
+
+1. Fork the repository and create your branch from `main`.
+2. Install dependencies with `pnpm install`.
+3. Run `pnpm lint` and `pnpm test` to ensure everything passes.
+
+## Submitting changes
+
+- Ensure code adheres to project style and passes all checks.
+- Submit a pull request describing your changes.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,9 @@
+# FAQ
+
+## Why was this project created?
+
+To compare translations of classic Zen texts side by side.
+
+## How can I report a bug or request a feature?
+
+Please open an issue on the GitHub repository.


### PR DESCRIPTION
## Summary
- add community docs for contributing, code of conduct, and FAQ
- expose documentation links in README and new site footer

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68947c3e0f9c83238805bd49f24a2c3a