### PR TITLE
feat: add multi-verse comparison

### DIFF
--- a/app/compare/multi/page.tsx
+++ b/app/compare/multi/page.tsx
@@ -1,0 +1,75 @@
+import { MultiVerseSelector } from "@/components/multi-verse-selector"
+import { db } from "@/lib/db"
+import { books, verses as versesTable, translations } from "@/lib/schema"
+import { asc, inArray } from "drizzle-orm"
+
+export default async function MultiComparePage({
+  searchParams,
+}: {
+  searchParams?: { verses?: string }
+}) {
+  const verseIds = searchParams?.verses?.split(",").filter(Boolean) || []
+
+  const allBooks = await db.query.books.findMany({
+    orderBy: (books, { asc }) => [asc(books.title)],
+    with: {
+      verses: {
+        orderBy: (versesTable, { asc }) => [asc(versesTable.number)],
+      },
+    },
+  })
+
+  let selectedVerses: {
+    id: string
+    number: number
+    book: { id: string; title: string }
+    translations: { id: string; translator: string; text: string }[]
+  }[] = []
+
+  if (verseIds.length > 0) {
+    selectedVerses = await db.query.verses.findMany({
+      where: inArray(versesTable.id, verseIds),
+      with: {
+        book: true,
+        translations: {
+          orderBy: (translations, { asc }) => [asc(translations.translator)],
+        },
+      },
+    })
+
+    selectedVerses.sort(
+      (a, b) => a.book.title.localeCompare(b.book.title) || a.number - b.number,
+    )
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col items-center p-4 md:p-24">
+      <div className="max-w-4xl w-full">
+        <h1 className="text-3xl font-bold mb-6">Compare Multiple Verses</h1>
+
+        <MultiVerseSelector books={allBooks} initialSelected={verseIds} />
+
+        <div className="space-y-8">
+          {selectedVerses.map((verse) => (
+            <div key={verse.id}>
+              <h2 className="text-xl font-semibold mb-4">
+                {verse.book.title} - Verse {verse.number}
+              </h2>
+              <div className="space-y-4">
+                {verse.translations.map((t) => (
+                  <div
+                    key={t.id}
+                    className="border-b pb-4 last:border-b-0 last:pb-0"
+                  >
+                    <h3 className="font-medium">{t.translator}</h3>
+                    <p className="whitespace-pre-line">{t.text}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/components/multi-verse-selector.tsx
+++ b/components/multi-verse-selector.tsx
@@ -1,0 +1,124 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { X } from "lucide-react"
+
+interface VerseInfo {
+  id: string
+  number: number
+}
+
+interface BookInfo {
+  id: string
+  title: string
+  verses: VerseInfo[]
+}
+
+interface MultiVerseSelectorProps {
+  books: BookInfo[]
+  initialSelected: string[]
+}
+
+export function MultiVerseSelector({ books, initialSelected }: MultiVerseSelectorProps) {
+  const router = useRouter()
+  const [bookId, setBookId] = useState<string>(books[0]?.id || "")
+  const [verseId, setVerseId] = useState<string>(books[0]?.verses[0]?.id || "")
+  const [selected, setSelected] = useState<string[]>(initialSelected)
+
+  useEffect(() => {
+    const currentBook = books.find((b) => b.id === bookId)
+    if (currentBook) {
+      if (!currentBook.verses.find((v) => v.id === verseId)) {
+        setVerseId(currentBook.verses[0]?.id || "")
+      }
+    }
+  }, [bookId, verseId, books])
+
+  const addVerse = () => {
+    if (verseId && !selected.includes(verseId)) {
+      setSelected((prev) => [...prev, verseId])
+    }
+  }
+
+  const removeVerse = (id: string) => {
+    setSelected((prev) => prev.filter((v) => v !== id))
+  }
+
+  const handleCompare = () => {
+    if (selected.length > 0) {
+      router.push(`/compare/multi?verses=${selected.join(",")}`)
+    }
+  }
+
+  const getVerseLabel = (id: string) => {
+    for (const book of books) {
+      const verse = book.verses.find((v) => v.id === id)
+      if (verse) {
+        return `${book.title} v${verse.number}`
+      }
+    }
+    return id
+  }
+
+  return (
+    <div className="mb-6">
+      <div className="flex flex-wrap gap-2 mb-2">
+        <Select value={bookId} onValueChange={setBookId}>
+          <SelectTrigger className="w-[200px]">
+            <SelectValue placeholder="Select book" />
+          </SelectTrigger>
+          <SelectContent>
+            {books.map((book) => (
+              <SelectItem key={book.id} value={book.id}>
+                {book.title}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select value={verseId} onValueChange={setVerseId}>
+          <SelectTrigger className="w-[120px]">
+            <SelectValue placeholder="Verse" />
+          </SelectTrigger>
+          <SelectContent>
+            {books
+              .find((b) => b.id === bookId)?.verses.map((v) => (
+                <SelectItem key={v.id} value={v.id}>
+                  Verse {v.number}
+                </SelectItem>
+              ))}
+          </SelectContent>
+        </Select>
+
+        <Button type="button" onClick={addVerse}>
+          Add
+        </Button>
+      </div>
+
+      <div className="flex flex-wrap gap-1 mb-2">
+        {selected.map((id) => (
+          <Badge key={id} variant="outline" className="flex items-center gap-1 pl-2 pr-1 py-0">
+            <span className="text-xs">{getVerseLabel(id)}</span>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-4 w-4 p-0 hover:bg-transparent"
+              onClick={() => removeVerse(id)}
+            >
+              <X size={10} />
+              <span className="sr-only">Remove</span>
+            </Button>
+          </Badge>
+        ))}
+      </div>
+
+      <Button onClick={handleCompare} disabled={selected.length === 0}>
+        Compare
+      </Button>
+    </div>
+  )
+}

--- a/components/multi-verse-selector.tsx
+++ b/components/multi-verse-selector.tsx
@@ -30,6 +30,10 @@ export function MultiVerseSelector({ books, initialSelected }: MultiVerseSelecto
   const [selected, setSelected] = useState<string[]>(initialSelected)
 
   useEffect(() => {
+    setSelected(initialSelected)
+  }, [initialSelected])
+
+  useEffect(() => {
     const currentBook = books.find((b) => b.id === bookId)
     if (currentBook) {
       if (!currentBook.verses.find((v) => v.id === verseId)) {


### PR DESCRIPTION
## Summary
- add MultiVerseSelector component for choosing verses across books
- create multi-verse comparison page displaying grouped translations

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68947c44225c8323b020f86e4d84bc5f