### PR TITLE
Add tags, bookmarks, and sorting features

### DIFF
--- a/app/api/bookmarks/route.test.ts
+++ b/app/api/bookmarks/route.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { promises as fs } from 'fs'
+import path from 'path'
+import os from 'os'
+
+let GET: () => Promise<Response>
+let POST: (req: Request) => Promise<Response>
+let DELETE: (req: Request) => Promise<Response>
+let tempDir: string
+
+beforeEach(async () => {
+  vi.resetModules()
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bookmarks-'))
+  vi.spyOn(process, 'cwd').mockReturnValue(tempDir)
+  ;({ GET, POST, DELETE } = await import('./route'))
+})
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  await fs.rm(tempDir, { recursive: true, force: true })
+})
+
+describe('bookmarks API', () => {
+  it('creates and retrieves bookmarks', async () => {
+    const postRes = await POST(
+      new Request('http://test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ verseId: '1' })
+      })
+    )
+    expect(postRes.status).toBe(200)
+    expect(await postRes.json()).toEqual({ verseId: '1' })
+
+    const getRes = await GET()
+    expect(getRes.status).toBe(200)
+    expect(await getRes.json()).toEqual(['1'])
+  })
+
+  it('deletes bookmarks', async () => {
+    await POST(
+      new Request('http://test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ verseId: '1' })
+      })
+    )
+
+    const deleteRes = await DELETE(
+      new Request('http://test', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ verseId: '1' })
+      })
+    )
+    expect(deleteRes.status).toBe(200)
+    expect(await deleteRes.json()).toEqual({ verseId: '1' })
+
+    const getRes = await GET()
+    expect(await getRes.json()).toEqual([])
+  })
+
+  it('errors on missing verseId for POST', async () => {
+    const res = await POST(
+      new Request('http://test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({})
+      })
+    )
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Missing verseId' })
+  })
+
+  it('errors on missing verseId for DELETE', async () => {
+    const res = await DELETE(
+      new Request('http://test', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({})
+      })
+    )
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Missing verseId' })
+  })
+})
+

--- a/app/api/bookmarks/route.ts
+++ b/app/api/bookmarks/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server"
+import { promises as fs } from "fs"
+import path from "path"
+
+const BOOKMARKS_FILE = path.join(process.cwd(), "data", "bookmarks.json")
+
+async function readData() {
+  try {
+    const data = await fs.readFile(BOOKMARKS_FILE, "utf8")
+    return JSON.parse(data || "[]") as string[]
+  } catch {
+    return [] as string[]
+  }
+}
+
+async function writeData(data: string[]) {
+  await fs.mkdir(path.dirname(BOOKMARKS_FILE), { recursive: true })
+  await fs.writeFile(BOOKMARKS_FILE, JSON.stringify(data, null, 2))
+}
+
+export async function GET() {
+  const data = await readData()
+  return NextResponse.json(data)
+}
+
+export async function POST(req: Request) {
+  const { verseId } = await req.json()
+  if (!verseId) {
+    return NextResponse.json({ error: "Missing verseId" }, { status: 400 })
+  }
+  const data = await readData()
+  if (!data.includes(verseId)) {
+    data.push(verseId)
+    await writeData(data)
+  }
+  return NextResponse.json({ verseId })
+}
+
+export async function DELETE(req: Request) {
+  const { verseId } = await req.json()
+  if (!verseId) {
+    return NextResponse.json({ error: "Missing verseId" }, { status: 400 })
+  }
+  let data = await readData()
+  data = data.filter((id) => id !== verseId)
+  await writeData(data)
+  return NextResponse.json({ verseId })
+}

--- a/app/books/page.tsx
+++ b/app/books/page.tsx
@@ -1,21 +1,54 @@
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { db } from "@/lib/db"
 
 export const revalidate = 60 // Revalidate data every 60 seconds
 
-export default async function BooksPage() {
+interface PageProps {
+  searchParams: {
+    q?: string
+    sort?: string
+  }
+}
+
+export default async function BooksPage({ searchParams }: PageProps) {
+  const sort = searchParams.sort === "recent" ? "recent" : "title"
+  const query = searchParams.q?.toLowerCase() ?? ""
+
   const allBooks = await db.query.books.findMany({
-    orderBy: (books, { asc }) => [asc(books.title)],
+    orderBy:
+      sort === "title"
+        ? (books, { asc }) => [asc(books.title)]
+        : (books, { desc }) => [desc(books.createdAt)],
   })
+
+  const filteredBooks = query
+    ? allBooks.filter((book) => book.title.toLowerCase().includes(query))
+    : allBooks
 
   return (
     <main className="flex min-h-screen flex-col items-center p-4 md:p-24">
       <div className="max-w-4xl w-full">
         <h1 className="text-3xl font-bold mb-6">Zen Texts Library</h1>
 
-        {allBooks.length === 0 ? (
+        <form className="flex flex-col md:flex-row gap-2 mb-6" action="" method="get">
+          <Input name="q" placeholder="Search books" defaultValue={searchParams.q || ""} />
+          <Select name="sort" defaultValue={sort}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder="Sort" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="title">Title</SelectItem>
+              <SelectItem value="recent">Newest</SelectItem>
+            </SelectContent>
+          </Select>
+          <Button type="submit">Apply</Button>
+        </form>
+
+        {filteredBooks.length === 0 ? (
           <Card className="p-6 text-center">
             <p className="mb-4 text-muted-foreground">The library is currently empty. Try seeding the database.</p>
             <Button asChild>
@@ -26,7 +59,7 @@ export default async function BooksPage() {
           </Card>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
-            {allBooks.map((book) => (
+            {filteredBooks.map((book) => (
               <Card key={book.id} className="overflow-hidden flex flex-col">
                 <div className="aspect-[3/2] relative">
                   <img

--- a/app/feed/page.tsx
+++ b/app/feed/page.tsx
@@ -1,0 +1,66 @@
+import { BookmarkButton } from "@/components/bookmark-button"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { verses } from "@/lib/translations"
+
+export const revalidate = 60
+
+interface PageProps {
+  searchParams: {
+    q?: string
+    sort?: string
+  }
+}
+
+export default function FeedPage({ searchParams }: PageProps) {
+  const query = searchParams.q?.toLowerCase() ?? ""
+  const sort = searchParams.sort === "desc" ? "desc" : "asc"
+
+  const filtered = verses
+    .filter((v) => {
+      if (!query) return true
+      return v.lines.some((line) =>
+        Object.values(line.translations).some((text) => text.toLowerCase().includes(query))
+      )
+    })
+    .sort((a, b) => (sort === "asc" ? a.id - b.id : b.id - a.id))
+
+  return (
+    <main className="flex min-h-screen flex-col items-center p-4 md:p-24">
+      <div className="max-w-4xl w-full">
+        <h1 className="text-3xl font-bold mb-6">Zen Feed</h1>
+
+        <form className="flex flex-col md:flex-row gap-2 mb-6" action="" method="get">
+          <Input name="q" placeholder="Search translations" defaultValue={searchParams.q || ""} />
+          <Select name="sort" defaultValue={sort}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder="Sort" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="asc">Verse Asc</SelectItem>
+              <SelectItem value="desc">Verse Desc</SelectItem>
+            </SelectContent>
+          </Select>
+          <Button type="submit">Apply</Button>
+        </form>
+
+        <div className="space-y-4">
+          {filtered.map((verse) => (
+            <div key={verse.id} className="border rounded p-4">
+              <div className="flex justify-between items-center mb-2">
+                <h2 className="font-semibold">Verse {verse.id}</h2>
+                <BookmarkButton verseId={verse.id.toString()} />
+              </div>
+              {verse.lines[0] && (
+                <p className="text-sm">
+                  {Object.values(verse.lines[0].translations)[0] || "Translation not available."}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/components/bookmark-button.tsx
+++ b/components/bookmark-button.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Bookmark, BookmarkCheck } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+interface BookmarkButtonProps {
+  verseId: string
+}
+
+export function BookmarkButton({ verseId }: BookmarkButtonProps) {
+  const [bookmarked, setBookmarked] = useState(false)
+
+  useEffect(() => {
+    let ignore = false
+    fetch("/api/bookmarks")
+      .then((res) => res.json())
+      .then((data: string[]) => {
+        if (!ignore) {
+          setBookmarked(data.includes(verseId))
+        }
+      })
+    return () => {
+      ignore = true
+    }
+  }, [verseId])
+
+  const toggle = async () => {
+    if (bookmarked) {
+      await fetch("/api/bookmarks", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ verseId }),
+      })
+      setBookmarked(false)
+    } else {
+      await fetch("/api/bookmarks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ verseId }),
+      })
+      setBookmarked(true)
+    }
+  }
+
+  return (
+    <Button variant="ghost" size="icon" onClick={toggle} aria-label={bookmarked ? "Remove bookmark" : "Add bookmark"}>
+      {bookmarked ? <BookmarkCheck className="h-4 w-4" /> : <Bookmark className="h-4 w-4" />}
+    </Button>
+  )
+}

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp, integer, boolean, uniqueIndex } from "drizzle-orm/pg-core"
+import { pgTable, text, timestamp, integer, boolean, uniqueIndex, primaryKey } from "drizzle-orm/pg-core"
 import { relations } from "drizzle-orm"
 
 // User table
@@ -109,6 +109,31 @@ export const comments = pgTable("comments", {
   updatedAt: timestamp("updated_at").notNull(),
 })
 
+// Tag table
+export const tags = pgTable("tags", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull().unique(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").notNull(),
+})
+
+// VerseTags join table
+export const versesToTags = pgTable(
+  "verses_tags",
+  {
+    verseId: text("verse_id")
+      .notNull()
+      .references(() => verses.id),
+    tagId: text("tag_id")
+      .notNull()
+      .references(() => tags.id),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.verseId, table.tagId] }),
+  })
+)
+
 // Session table
 export const sessions = pgTable("sessions", {
   id: text("id").primaryKey(),
@@ -130,6 +155,7 @@ export const versesRelations = relations(verses, ({ one, many }) => ({
   translations: many(translations),
   notes: many(notes),
   comments: many(comments),
+  verseTags: many(versesToTags),
 }))
 
 export const translationsRelations = relations(translations, ({ one, many }) => ({
@@ -177,6 +203,21 @@ export const commentsRelations = relations(comments, ({ one }) => ({
   verse: one(verses, {
     fields: [comments.verseId],
     references: [verses.id],
+  }),
+}))
+
+export const tagsRelations = relations(tags, ({ many }) => ({
+  verseTags: many(versesToTags),
+}))
+
+export const versesToTagsRelations = relations(versesToTags, ({ one }) => ({
+  verse: one(verses, {
+    fields: [versesToTags.verseId],
+    references: [verses.id],
+  }),
+  tag: one(tags, {
+    fields: [versesToTags.tagId],
+    references: [tags.id],
   }),
 }))
 


### PR DESCRIPTION
## Summary
- add `tags` and `verses_tags` tables with relations
- implement simple bookmark API and UI button
- support search and sorting on books and new feed pages

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689477cf3fc08323b63dfd9169433d71