### PR TITLE
feat: add user profile and follow api

### DIFF
--- a/app/api/users/[userId]/follow.ts
+++ b/app/api/users/[userId]/follow.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { userFollows } from "@/lib/schema"
+import { eq, and } from "drizzle-orm"
+
+interface RouteParams {
+  params: { userId: string }
+}
+
+export async function POST(req: Request, { params }: RouteParams) {
+  const { followerId } = await req.json()
+  if (!followerId) {
+    return NextResponse.json({ error: "Missing followerId" }, { status: 400 })
+  }
+
+  await db
+    .insert(userFollows)
+    .values({
+      followerId,
+      followingId: params.userId,
+    })
+    .onConflictDoNothing()
+
+  return NextResponse.json({ success: true })
+}
+
+export async function DELETE(req: Request, { params }: RouteParams) {
+  const { followerId } = await req.json()
+  if (!followerId) {
+    return NextResponse.json({ error: "Missing followerId" }, { status: 400 })
+  }
+
+  await db
+    .delete(userFollows)
+    .where(
+      and(
+        eq(userFollows.followerId, followerId),
+        eq(userFollows.followingId, params.userId)
+      )
+    )
+
+  return NextResponse.json({ success: true })
+}

--- a/app/users/[userId]/page.tsx
+++ b/app/users/[userId]/page.tsx
@@ -1,0 +1,127 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { db } from "@/lib/db"
+import { comments, notes, users } from "@/lib/schema"
+import { eq, desc } from "drizzle-orm"
+import Link from "next/link"
+import { notFound } from "next/navigation"
+
+const PAGE_SIZE = 5
+
+interface PageProps {
+  params: { userId: string }
+  searchParams: { [key: string]: string | string[] | undefined }
+}
+
+export default async function UserPage({ params, searchParams }: PageProps) {
+  const user = await db.query.users.findFirst({
+    where: eq(users.id, params.userId),
+  })
+
+  if (!user) {
+    notFound()
+  }
+
+  const notesPage = Number((searchParams.notesPage as string) || "1")
+  const commentsPage = Number((searchParams.commentsPage as string) || "1")
+
+  const userNotes = await db.query.notes.findMany({
+    where: eq(notes.userId, params.userId),
+    orderBy: (n, { desc }) => [desc(n.createdAt)],
+    limit: PAGE_SIZE,
+    offset: (notesPage - 1) * PAGE_SIZE,
+  })
+
+  const userComments = await db.query.comments.findMany({
+    where: eq(comments.userId, params.userId),
+    orderBy: (c, { desc }) => [desc(c.createdAt)],
+    limit: PAGE_SIZE,
+    offset: (commentsPage - 1) * PAGE_SIZE,
+  })
+
+  return (
+    <main className="max-w-2xl mx-auto p-4 space-y-8">
+      <div className="flex items-center gap-4">
+        <Avatar className="h-16 w-16">
+          {user.avatarUrl ? (
+            <AvatarImage src={user.avatarUrl} alt={user.username} />
+          ) : (
+            <AvatarFallback>
+              {user.username.slice(0, 2).toUpperCase()}
+            </AvatarFallback>
+          )}
+        </Avatar>
+        <div>
+          <h1 className="text-2xl font-bold">@{user.username}</h1>
+          {user.bio && <p className="text-muted-foreground">{user.bio}</p>}
+          <p className="text-sm text-muted-foreground">
+            Joined {user.createdAt.toLocaleDateString()}
+          </p>
+        </div>
+      </div>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Notes</h2>
+        <ul className="space-y-2">
+          {userNotes.map((note) => (
+            <li key={note.id} className="border p-2 rounded">
+              {note.content}
+            </li>
+          ))}
+        </ul>
+        <div className="flex justify-between mt-2">
+          {notesPage > 1 ? (
+            <Link
+              href={`/users/${params.userId}?notesPage=${notesPage - 1}&commentsPage=${commentsPage}`}
+              className="text-sm"
+            >
+              Previous
+            </Link>
+          ) : (
+            <span />
+          )}
+          {userNotes.length === PAGE_SIZE && (
+            <Link
+              href={`/users/${params.userId}?notesPage=${notesPage + 1}&commentsPage=${commentsPage}`}
+              className="text-sm"
+            >
+              Next
+            </Link>
+          )}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Comments</h2>
+        <ul className="space-y-2">
+          {userComments.map((comment) => (
+            <li key={comment.id} className="border p-2 rounded">
+              {comment.content}
+            </li>
+          ))}
+        </ul>
+        <div className="flex justify-between mt-2">
+          {commentsPage > 1 ? (
+            <Link
+              href={`/users/${params.userId}?notesPage=${notesPage}&commentsPage=${commentsPage - 1}`}
+              className="text-sm"
+            >
+              Previous
+            </Link>
+          ) : (
+            <span />
+          )}
+          {userComments.length === PAGE_SIZE && (
+            <Link
+              href={`/users/${params.userId}?notesPage=${notesPage}&commentsPage=${commentsPage + 1}`}
+              className="text-sm"
+            >
+              Next
+            </Link>
+          )}
+        </div>
+      </section>
+    </main>
+  )
+}
+
+export const revalidate = 60

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,12 +17,16 @@ model User {
   username  String   @unique
   password  String
   isGuest   Boolean  @default(false)
+  avatar    String?
+  bio       String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-  
+
   favorites Favorite[]
   notes     Note[]
   comments  Comment[]
+  followers UserFollow[] @relation("followers")
+  following UserFollow[] @relation("following")
 }
 
 model Book {
@@ -107,6 +111,16 @@ model Comment {
   verse     Verse    @relation(fields: [verseId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+model UserFollow {
+  follower   User   @relation("following", fields: [followerId], references: [id])
+  followerId String
+  following  User   @relation("followers", fields: [followingId], references: [id])
+  followingId String
+  createdAt  DateTime @default(now())
+
+  @@id([followerId, followingId])
 }
 
 model Session {

--- a/tests/follow.test.ts
+++ b/tests/follow.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const follows = new Set<string>()
+
+vi.mock('@/lib/db', () => {
+  return {
+    db: {
+      insert: () => ({
+        values: ({ followerId, followingId }: any) => ({
+          onConflictDoNothing: async () => {
+            follows.add(`${followerId}:${followingId}`)
+          },
+        }),
+      }),
+      delete: () => ({
+        where: async () => {},
+      }),
+    },
+  }
+})
+
+import { POST, DELETE } from '../app/api/users/[userId]/follow'
+
+const userId = 'user2'
+const followerId = 'user1'
+
+beforeEach(() => {
+  follows.clear()
+})
+
+describe('follow API', () => {
+  it('follows a user', async () => {
+    const res = await POST(
+      new Request('http://test', {
+        method: 'POST',
+        body: JSON.stringify({ followerId }),
+      }),
+      { params: { userId } }
+    )
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true })
+  })
+
+  it('unfollows a user', async () => {
+    const res = await DELETE(
+      new Request('http://test', {
+        method: 'DELETE',
+        body: JSON.stringify({ followerId }),
+      }),
+      { params: { userId } }
+    )
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true })
+  })
+
+  it('requires followerId', async () => {
+    const res = await POST(
+      new Request('http://test', {
+        method: 'POST',
+        body: JSON.stringify({}),
+      }),
+      { params: { userId } }
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('is idempotent for follow', async () => {
+    await POST(
+      new Request('http://test', {
+        method: 'POST',
+        body: JSON.stringify({ followerId }),
+      }),
+      { params: { userId } }
+    )
+    const res = await POST(
+      new Request('http://test', {
+        method: 'POST',
+        body: JSON.stringify({ followerId }),
+      }),
+      { params: { userId } }
+    )
+    expect(res.status).toBe(200)
+    expect(follows.size).toBe(1)
+  })
+
+  it('is idempotent for unfollow', async () => {
+    await DELETE(
+      new Request('http://test', {
+        method: 'DELETE',
+        body: JSON.stringify({ followerId }),
+      }),
+      { params: { userId } }
+    )
+    const res = await DELETE(
+      new Request('http://test', {
+        method: 'DELETE',
+        body: JSON.stringify({ followerId }),
+      }),
+      { params: { userId } }
+    )
+    expect(res.status).toBe(200)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- add optional avatar and bio columns and follower join table
- expose user profile page listing notes and comments with pagination
- create follow/unfollow API endpoint for user relationships
- ensure follow endpoint is idempotent and covered by unit tests

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68947cc66ce483238c3af94a6f67856d