### PR TITLE
Add quote API, zen mode, and comment timer

### DIFF
--- a/app/api/quotes/route.ts
+++ b/app/api/quotes/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server"
+import { promises as fs } from "fs"
+import path from "path"
+
+const QUOTES_FILE = path.join(process.cwd(), "data", "quotes.json")
+
+async function fetchFromReddit() {
+  try {
+    const res = await fetch(
+      "https://www.reddit.com/r/quotes/top.json?limit=50",
+      { next: { revalidate: 86400 } }
+    )
+    const data = await res.json()
+    const posts = data?.data?.children
+    if (!Array.isArray(posts) || posts.length === 0) return null
+    const day = new Date()
+    const index = getDayOfYear(day) % posts.length
+    const post = posts[index].data
+    return {
+      text: post.title,
+      author: post.author,
+    }
+  } catch {
+    return null
+  }
+}
+
+function getDayOfYear(date: Date) {
+  const start = new Date(date.getFullYear(), 0, 0)
+  const diff = date.getTime() - start.getTime()
+  return Math.floor(diff / (1000 * 60 * 60 * 24))
+}
+
+async function fetchFromStatic() {
+  try {
+    const data = await fs.readFile(QUOTES_FILE, "utf8")
+    const quotes = JSON.parse(data)
+    const index = getDayOfYear(new Date()) % quotes.length
+    return quotes[index]
+  } catch {
+    return null
+  }
+}
+
+export async function GET() {
+  const quote =
+    (await fetchFromReddit()) ||
+    (await fetchFromStatic()) || { text: "Be present.", author: "Unknown" }
+  return NextResponse.json(quote)
+}

--- a/components/comment-timer.tsx
+++ b/components/comment-timer.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+interface CommentTimerProps {
+  seconds?: number
+  onComplete?: () => void
+}
+
+export function CommentTimer({ seconds = 5, onComplete }: CommentTimerProps) {
+  const [timeLeft, setTimeLeft] = useState(seconds)
+
+  useEffect(() => {
+    if (timeLeft <= 0) {
+      onComplete?.()
+      return
+    }
+    const id = setTimeout(() => setTimeLeft(timeLeft - 1), 1000)
+    return () => clearTimeout(id)
+  }, [timeLeft, onComplete])
+
+  return (
+    <div className="text-sm text-muted-foreground">
+      {timeLeft > 0 ? `Pause for ${timeLeft}…` : "You may comment now."}
+    </div>
+  )
+}

--- a/data/quotes.json
+++ b/data/quotes.json
@@ -1,0 +1,5 @@
+[
+  { "text": "Peace comes from within. Do not seek it without.", "author": "Buddha" },
+  { "text": "The greatest wealth is to live content with little.", "author": "Plato" },
+  { "text": "Simplicity is the ultimate sophistication.", "author": "Leonardo da Vinci" }
+]

--- a/styles/zen-mode.css
+++ b/styles/zen-mode.css
@@ -1,0 +1,16 @@
+/* Minimalist Zen Mode styles */
+body.zen-mode {
+  margin: 0 auto;
+  max-width: 65ch;
+  padding: 2rem;
+  background-color: #f7f7f5;
+  color: #111;
+  font-family: Georgia, serif;
+  line-height: 1.8;
+}
+
+body.zen-mode img,
+body.zen-mode nav,
+body.zen-mode footer {
+  display: none;
+}

--- a/tests/quotes.test.ts
+++ b/tests/quotes.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { GET } from '../app/api/quotes/route'
+import { promises as fs } from 'fs'
+
+const defaultQuote = { text: 'Be present.', author: 'Unknown' }
+
+describe('GET /api/quotes', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns reddit quote when fetch succeeds', async () => {
+    const redditQuote = { text: 'Reddit quote', author: 'redditUser' }
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      json: async () => ({ data: { children: [{ data: { title: redditQuote.text, author: redditQuote.author } }] } })
+    } as any)
+
+    const res = await GET()
+    const json = await res.json()
+    expect(json).toEqual(redditQuote)
+  })
+
+  it('falls back to static quote when reddit fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network'))
+    const staticQuote = { text: 'Static quote', author: 'File' }
+    vi.spyOn(fs, 'readFile').mockResolvedValue(JSON.stringify([staticQuote]))
+
+    const res = await GET()
+    const json = await res.json()
+    expect(json).toEqual(staticQuote)
+  })
+
+  it('returns default quote when both sources fail', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network'))
+    vi.spyOn(fs, 'readFile').mockRejectedValue(new Error('fs'))
+
+    const res = await GET()
+    const json = await res.json()
+    expect(json).toEqual(defaultQuote)
+  })
+
+  it('returns default quote when quotes.json is empty', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network'))
+    vi.spyOn(fs, 'readFile').mockResolvedValue('[]')
+
+    const res = await GET()
+    const json = await res.json()
+    expect(json).toEqual(defaultQuote)
+  })
+
+  it('uses static fallback when reddit response is malformed', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      json: async () => ({ data: { children: null } })
+    } as any)
+    const staticQuote = { text: 'Static quote', author: 'File' }
+    vi.spyOn(fs, 'readFile').mockResolvedValue(JSON.stringify([staticQuote]))
+
+    const res = await GET()
+    const json = await res.json()
+    expect(json).toEqual(staticQuote)
+  })
+
+  it('returns object with text and author fields', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      json: async () => ({ data: { children: [{ data: { title: 'A', author: 'B' } }] } })
+    } as any)
+
+    const res = await GET()
+    const json = await res.json()
+    expect(json).toHaveProperty('text')
+    expect(json).toHaveProperty('author')
+  })
+})


### PR DESCRIPTION
## Summary
- add daily quote API with Reddit sourcing and static fallback
- introduce zen mode stylesheet for minimalist reading
- implement mindful commenting timer component
- add tests covering quote API fallbacks and edge cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68947cd31bec83238d654d821abf49a1