### PR TITLE
feat: add basic gamification

### DIFF
--- a/app/api/comments/route.ts
+++ b/app/api/comments/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from "next/server"
 import { promises as fs } from "fs"
 import path from "path"
+import { addKarmaPoints } from "../../../lib/gamification"
 
 export interface Comment {
   id: string
   content: string
   createdAt: string
   votes: number
+  userId: string
 }
 
 const COMMENTS_FILE = path.join(process.cwd(), "data", "comments.json")
@@ -50,8 +52,8 @@ export async function GET(req: Request) {
 }
 
 export async function POST(req: Request) {
-  const { verseId, content } = await req.json()
-  if (!verseId || !content) {
+  const { verseId, content, userId } = await req.json()
+  if (!verseId || !content || !userId) {
     return NextResponse.json({ error: "Missing fields" }, { status: 400 })
   }
   const data = await readData()
@@ -60,10 +62,12 @@ export async function POST(req: Request) {
     content,
     createdAt: new Date().toISOString(),
     votes: 0,
+    userId,
   }
   if (!data[verseId]) data[verseId] = []
   data[verseId].push(comment)
   await writeData(data)
+  await addKarmaPoints(userId, "comment")
   return NextResponse.json(comment)
 }
 

--- a/app/books/[bookId]/verses/[verseId]/page.tsx
+++ b/app/books/[bookId]/verses/[verseId]/page.tsx
@@ -51,7 +51,7 @@ export default async function VersePage({
           </div>
         </div>
 
-        <CommentSection verseId={params.verseId} />
+        <CommentSection verseId={params.verseId} userId="demo-user" />
 
         <div className="flex justify-between">
           <Link

--- a/app/users/[userId]/page.tsx
+++ b/app/users/[userId]/page.tsx
@@ -1,0 +1,49 @@
+import { notFound } from 'next/navigation'
+import { db } from '@/lib/db'
+import { eq } from 'drizzle-orm'
+import { Progress } from '@/components/ui/progress'
+import { getBadge, getNextBadge, progressToNextBadge, calculateStreak } from '@/lib/gamification'
+import { promises as fs } from 'fs'
+import path from 'path'
+
+interface StoredComment { userId: string; createdAt: string }
+
+export default async function UserProfile({ params }: { params: { userId: string } }) {
+  const user = await db.query.users.findFirst({
+    where: (usersTable, { eq }) => eq(usersTable.id, params.userId),
+  })
+  if (!user) notFound()
+
+  let commentData: Record<string, StoredComment[]> = {}
+  try {
+    const file = await fs.readFile(path.join(process.cwd(), 'data', 'comments.json'), 'utf8')
+    commentData = JSON.parse(file || '{}')
+  } catch {}
+
+  const dates = Object.values(commentData)
+    .flat()
+    .filter((c) => c.userId === user.id)
+    .map((c) => new Date(c.createdAt))
+
+  const streak = calculateStreak(dates)
+  const badge = getBadge(user.karma)
+  const nextBadge = getNextBadge(user.karma)
+  const progress = progressToNextBadge(user.karma)
+
+  return (
+    <div className="p-6 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">{user.username}</h1>
+      <p className="mb-2">Karma: {user.karma}</p>
+      <p className="mb-2">Badge: {badge}</p>
+      {nextBadge && (
+        <div className="mb-4">
+          <Progress value={progress} />
+          <p className="text-sm mt-1">
+            {user.karma} / {nextBadge.threshold} to {nextBadge.name}
+          </p>
+        </div>
+      )}
+      <p>Current streak: {streak} day{streak === 1 ? '' : 's'}</p>
+    </div>
+  )
+}

--- a/components/comment-section.tsx
+++ b/components/comment-section.tsx
@@ -7,9 +7,10 @@ interface Comment {
   content: string
   createdAt: string
   votes: number
+  userId: string
 }
 
-export function CommentSection({ verseId }: { verseId: string }) {
+export function CommentSection({ verseId, userId }: { verseId: string; userId: string }) {
   const [comments, setComments] = useState<Comment[]>([])
   const [content, setContent] = useState("")
 
@@ -28,7 +29,7 @@ export function CommentSection({ verseId }: { verseId: string }) {
     await fetch("/api/comments", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ verseId, content })
+      body: JSON.stringify({ verseId, content, userId })
     })
     setContent("")
     load()

--- a/lib/gamification.ts
+++ b/lib/gamification.ts
@@ -1,0 +1,68 @@
+import { users } from './schema'
+import { eq, sql } from 'drizzle-orm'
+
+export const KARMA_VALUES = {
+  comment: 1,
+  highlight: 1,
+} as const
+
+type KarmaAction = keyof typeof KARMA_VALUES
+
+export async function addKarmaPoints(userId: string, action: KarmaAction) {
+  const { db } = await import('./db')
+  const points = KARMA_VALUES[action]
+  await db
+    .update(users)
+    .set({ karma: sql`${users.karma} + ${points}` })
+    .where(eq(users.id, userId))
+}
+
+export const BADGES = [
+  { name: 'Novice', threshold: 0 },
+  { name: 'Contributor', threshold: 10 },
+  { name: 'Scholar', threshold: 50 },
+  { name: 'Master', threshold: 100 },
+]
+
+export function getBadge(karma: number) {
+  let current = BADGES[0]
+  for (const b of BADGES) {
+    if (karma >= b.threshold) current = b
+    else break
+  }
+  return current.name
+}
+
+export function getNextBadge(karma: number) {
+  for (const b of BADGES) {
+    if (karma < b.threshold) return b
+  }
+  return null
+}
+
+export function progressToNextBadge(karma: number) {
+  const next = getNextBadge(karma)
+  if (!next) return 100
+  const currentIndex = BADGES.findIndex((b) => b.threshold === next.threshold) - 1
+  const current = BADGES[Math.max(currentIndex, 0)]
+  const range = next.threshold - current.threshold
+  return ((karma - current.threshold) / range) * 100
+}
+
+export function calculateStreak(dates: Date[]) {
+  const uniqueDays = Array.from(
+    new Set(dates.map((d) => d.toISOString().slice(0, 10)))
+  )
+    .map((d) => new Date(d))
+    .sort((a, b) => b.getTime() - a.getTime())
+
+  let streak = 0
+  const today = new Date()
+  for (const day of uniqueDays) {
+    const expected = new Date()
+    expected.setDate(today.getDate() - streak)
+    if (day.toDateString() === expected.toDateString()) streak++
+    else if (day < expected) break
+  }
+  return streak
+}

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -10,6 +10,7 @@ export const users = pgTable("users", {
   isGuest: boolean("is_guest").default(false).notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").notNull(),
+  karma: integer("karma").default(0).notNull(),
 })
 
 // Book table

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,7 +19,8 @@ model User {
   isGuest   Boolean  @default(false)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-  
+  karma     Int      @default(0)
+
   favorites Favorite[]
   notes     Note[]
   comments  Comment[]

--- a/tests/comments.test.ts
+++ b/tests/comments.test.ts
@@ -4,7 +4,7 @@ import { voteComment, Comment } from '../app/api/comments/route'
 describe('voteComment', () => {
   it('increments vote count', () => {
     const data: Record<string, Comment[]> = {
-      verse1: [{ id: 'a', content: 'hi', createdAt: '', votes: 0 }]
+      verse1: [{ id: 'a', content: 'hi', createdAt: '', votes: 0, userId: 'u1' }]
     }
     const updated = voteComment(data, 'verse1', 'a', 1)
     expect(updated?.votes).toBe(1)

--- a/tests/gamification.test.ts
+++ b/tests/gamification.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  getBadge,
+  calculateStreak,
+  progressToNextBadge,
+  addKarmaPoints,
+} from '../lib/gamification'
+import { sql } from 'drizzle-orm'
+import { PGlite } from '@electric-sql/pglite'
+import { drizzle } from 'drizzle-orm/pglite'
+
+let db: any
+
+vi.mock('../lib/db', () => ({
+  get db() {
+    return db
+  },
+}))
+
+describe('gamification helpers', () => {
+  it('awards badges based on karma', () => {
+    expect(getBadge(0)).toBe('Novice')
+    expect(getBadge(60)).toBe('Scholar')
+  })
+
+  it('calculates activity streak', () => {
+    const today = new Date()
+    const yesterday = new Date()
+    yesterday.setDate(today.getDate() - 1)
+    expect(calculateStreak([today, yesterday])).toBe(2)
+  })
+
+  it('computes progress to next badge', () => {
+    expect(progressToNextBadge(5)).toBeCloseTo(50)
+  })
+
+  it('adds karma points for a comment', async () => {
+    db = drizzle(new PGlite())
+    await db.execute(
+      sql`create table users (id text primary key, karma integer default 0)`
+    )
+    await db.execute(sql`insert into users (id, karma) values ('u1', 0)`)
+    await addKarmaPoints('u1', 'comment')
+    const res = await db.execute(
+      sql`select karma from users where id = 'u1'`
+    )
+    expect(res.rows[0].karma).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- track karma points on users and increment after comments
- add badge thresholds and streak helpers
- show karma progress and streak info on profile pages
- add test covering karma increments from actions

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68947ccebf8483238d07674f515bf6c6