### PR TITLE
Add highlight support with privacy options

### DIFF
--- a/app/api/highlights/route.ts
+++ b/app/api/highlights/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from "next/server"
+import { promises as fs } from "fs"
+import path from "path"
+
+export interface Highlight {
+  id: string
+  verseId: string
+  userId: string
+  start: number
+  end: number
+  content?: string
+  isPublic: boolean
+  createdAt: string
+}
+
+const HIGHLIGHTS_FILE = path.join(process.cwd(), "data", "highlights.json")
+
+async function readData() {
+  try {
+    const data = await fs.readFile(HIGHLIGHTS_FILE, "utf8")
+    return JSON.parse(data || "{}")
+  } catch {
+    return {}
+  }
+}
+
+async function writeData(data: Record<string, Highlight[]>) {
+  await fs.mkdir(path.dirname(HIGHLIGHTS_FILE), { recursive: true })
+  await fs.writeFile(HIGHLIGHTS_FILE, JSON.stringify(data, null, 2))
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const verseId = searchParams.get("verseId")
+  const data = await readData()
+  if (verseId) {
+    return NextResponse.json(data[verseId] || [])
+  }
+  return NextResponse.json(data)
+}
+
+export async function POST(req: Request) {
+  const { verseId, userId, start, end, content, isPublic } = await req.json()
+  if (!verseId || !userId || typeof start !== "number" || typeof end !== "number") {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 })
+  }
+  const data = await readData()
+  const highlight: Highlight = {
+    id: crypto.randomUUID(),
+    verseId,
+    userId,
+    start,
+    end,
+    content,
+    isPublic: !!isPublic,
+    createdAt: new Date().toISOString(),
+  }
+  if (!data[verseId]) data[verseId] = []
+  data[verseId].push(highlight)
+  await writeData(data)
+  return NextResponse.json(highlight)
+}
+
+export async function PATCH(req: Request) {
+  const { verseId, highlightId, isPublic } = await req.json()
+  if (!verseId || !highlightId || typeof isPublic !== "boolean") {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 })
+  }
+  const data = await readData()
+  const list = data[verseId]
+  if (!list) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+  const highlight = list.find((h) => h.id === highlightId)
+  if (!highlight) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+  highlight.isPublic = isPublic
+  await writeData(data)
+  return NextResponse.json(highlight)
+}

--- a/components/verse-viewer.tsx
+++ b/components/verse-viewer.tsx
@@ -1,0 +1,95 @@
+"use client"
+
+import { useState, useRef } from "react"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { Switch } from "@/components/ui/switch"
+import { Label } from "@/components/ui/label"
+
+interface VerseViewerProps {
+  verseId: string
+  text: string
+  userId: string
+}
+
+export function VerseViewer({ verseId, text, userId }: VerseViewerProps) {
+  const verseRef = useRef<HTMLParagraphElement>(null)
+  const [selection, setSelection] = useState<{ start: number; end: number; text: string } | null>(null)
+  const [note, setNote] = useState("")
+  const [isPublic, setIsPublic] = useState(false)
+
+  function handleMouseUp() {
+    const sel = window.getSelection()
+    if (sel && sel.rangeCount > 0 && verseRef.current) {
+      const range = sel.getRangeAt(0)
+      if (!range.collapsed && verseRef.current.contains(range.commonAncestorContainer)) {
+        // Measure text length from the start of the verse element to the
+        // selection boundaries. This accounts for selections that span across
+        // multiple nodes or include rich markup. It relies on the DOM's
+        // text representation, so offsets may be off if the displayed text
+        // differs from the `text` prop (e.g. hidden elements or Unicode
+        // normalization).
+        const preRange = document.createRange()
+        preRange.selectNodeContents(verseRef.current)
+        preRange.setEnd(range.startContainer, range.startOffset)
+        const start = preRange.toString().length
+
+        const postRange = document.createRange()
+        postRange.selectNodeContents(verseRef.current)
+        postRange.setEnd(range.endContainer, range.endOffset)
+        const end = postRange.toString().length
+
+        setSelection({ start, end, text: sel.toString() })
+      } else {
+        setSelection(null)
+      }
+    }
+  }
+
+  async function saveHighlight() {
+    if (!selection) return
+    await fetch("/api/highlights", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        verseId,
+        userId,
+        start: selection.start,
+        end: selection.end,
+        content: note,
+        isPublic,
+      }),
+    })
+    setSelection(null)
+    setNote("")
+    setIsPublic(false)
+  }
+
+  return (
+    <div>
+      <p
+        ref={verseRef}
+        onMouseUp={handleMouseUp}
+        className="cursor-text select-text"
+      >
+        {text}
+      </p>
+      {selection && (
+        <div className="mt-2 space-y-2">
+          <Textarea
+            placeholder="Add a note (optional)"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+          />
+          <div className="flex items-center gap-2">
+            <Switch id="highlight-public" checked={isPublic} onCheckedChange={setIsPublic} />
+            <Label htmlFor="highlight-public">Public</Label>
+          </div>
+          <Button size="sm" onClick={saveHighlight}>
+            Save Highlight
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -109,6 +109,23 @@ export const comments = pgTable("comments", {
   updatedAt: timestamp("updated_at").notNull(),
 })
 
+// Highlight table
+export const highlights = pgTable("highlights", {
+  id: text("id").primaryKey(),
+  start: integer("start").notNull(),
+  end: integer("end").notNull(),
+  content: text("content"),
+  isPublic: boolean("is_public").default(false).notNull(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id),
+  verseId: text("verse_id")
+    .notNull()
+    .references(() => verses.id),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").notNull(),
+})
+
 // Session table
 export const sessions = pgTable("sessions", {
   id: text("id").primaryKey(),
@@ -130,6 +147,7 @@ export const versesRelations = relations(verses, ({ one, many }) => ({
   translations: many(translations),
   notes: many(notes),
   comments: many(comments),
+  highlights: many(highlights),
 }))
 
 export const translationsRelations = relations(translations, ({ one, many }) => ({
@@ -145,6 +163,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   notes: many(notes),
   comments: many(comments),
   sessions: many(sessions),
+  highlights: many(highlights),
 }))
 
 export const favoritesRelations = relations(favorites, ({ one }) => ({
@@ -176,6 +195,17 @@ export const commentsRelations = relations(comments, ({ one }) => ({
   }),
   verse: one(verses, {
     fields: [comments.verseId],
+    references: [verses.id],
+  }),
+}))
+
+export const highlightsRelations = relations(highlights, ({ one }) => ({
+  user: one(users, {
+    fields: [highlights.userId],
+    references: [users.id],
+  }),
+  verse: one(verses, {
+    fields: [highlights.verseId],
     references: [verses.id],
   }),
 }))


### PR DESCRIPTION
## Summary
- add `highlights` table linking users and verse segments
- enable verse viewer to select text and save highlights or notes
- add API route for saving highlights with public/private toggle
- ensure verse selection offsets are computed across rich markup

## Testing
- `npm test`
- `npm run lint` *(prompts to configure Next.js ESLint plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68947cc7e17c8323ba0551b6c7722bb6