### PR TITLE
Add theme switcher, keyboard shortcuts, and mobile styles

### DIFF
--- a/components/theme-switcher.tsx
+++ b/components/theme-switcher.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Moon, Sun } from "lucide-react"
+
+export function ThemeSwitcher() {
+  const [isDark, setIsDark] = useState(false)
+
+  useEffect(() => {
+    const root = window.document.documentElement
+    const stored = window.localStorage.getItem("theme")
+    const initial = stored ? stored === "dark" : root.classList.contains("dark")
+    root.classList.toggle("dark", initial)
+    setIsDark(initial)
+  }, [])
+
+  function toggleTheme() {
+    const next = !isDark
+    const root = window.document.documentElement
+    root.classList.toggle("dark", next)
+    window.localStorage.setItem("theme", next ? "dark" : "light")
+    setIsDark(next)
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleTheme}
+      aria-label="Toggle theme"
+    >
+      {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </Button>
+  )
+}

--- a/hooks/use-shortcuts.ts
+++ b/hooks/use-shortcuts.ts
@@ -1,0 +1,28 @@
+"use client"
+
+import { useEffect } from "react"
+
+interface ShortcutOptions {
+  onNextVerse?: () => void
+  onSearch?: () => void
+}
+
+export function useShortcuts({ onNextVerse, onSearch }: ShortcutOptions) {
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "ArrowRight") {
+        onNextVerse?.()
+      }
+      if (e.key === "/") {
+        const tag = (e.target as HTMLElement).tagName
+        if (tag !== "INPUT" && tag !== "TEXTAREA") {
+          e.preventDefault()
+          onSearch?.()
+        }
+      }
+    }
+
+    window.addEventListener("keydown", handleKey)
+    return () => window.removeEventListener("keydown", handleKey)
+  }, [onNextVerse, onSearch])
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -92,3 +92,11 @@ body {
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  @media (max-width: 640px) {
+    body {
+      @apply px-4 text-sm;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add ThemeSwitcher component using Tailwind dark mode
- provide useShortcuts hook for keyboard controls
- tweak global styles for mobile responsiveness

## Testing
- `pnpm lint` *(fails: prompts for ESLint configuration)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689477d0e8048323a8ed34db579f1538