### PR TITLE
feat: add postgres db, caching, and pagination

### DIFF
--- a/app/api/translations/route.test.ts
+++ b/app/api/translations/route.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// sample data for translations
+const sample = [
+  { id: 't1', verseId: '1', translator: 'A', text: 'one' },
+  { id: 't2', verseId: '1', translator: 'B', text: 'two' },
+  { id: 't3', verseId: '1', translator: 'C', text: 'three' },
+]
+
+// mock database
+const findMany = vi.fn(({ limit, offset }) => sample.slice(offset, offset + limit))
+vi.mock('@/lib/db', () => ({
+  db: { query: { translations: { findMany } } }
+}))
+vi.mock('@/lib/schema', () => ({ translations: {}, verses: {} }))
+
+// mock redis with in-memory store to verify caching
+const store = new Map<string, any>()
+const get = vi.fn(async (key: string) => store.get(key))
+const set = vi.fn(async (key: string, value: any) => { store.set(key, value) })
+vi.mock('@/lib/redis', () => ({
+  redis: { get, set }
+}))
+
+// import the handler after mocks are set up
+const { GET } = await import('./route')
+
+beforeEach(() => {
+  store.clear()
+  vi.clearAllMocks()
+})
+
+describe('GET /api/translations', () => {
+  it('paginates results', async () => {
+    const req1 = new Request('http://test?verseId=1&page=1&limit=2')
+    const res1 = await GET(req1)
+    const body1 = await res1.json()
+    expect(body1).toEqual(sample.slice(0, 2))
+
+    const req2 = new Request('http://test?verseId=1&page=2&limit=2')
+    const res2 = await GET(req2)
+    const body2 = await res2.json()
+    expect(body2).toEqual(sample.slice(2, 4))
+  })
+
+  it('caches responses for identical queries', async () => {
+    const req = new Request('http://test?verseId=1&page=1&limit=2')
+    await GET(req)
+    await GET(req)
+
+    expect(get).toHaveBeenCalledTimes(2)
+    expect(set).toHaveBeenCalledTimes(1)
+    expect(findMany).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns 400 if verseId missing', async () => {
+    const req = new Request('http://test')
+    const res = await GET(req)
+    expect(res.status).toBe(400)
+  })
+})

--- a/app/api/translations/route.ts
+++ b/app/api/translations/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { translations } from "@/lib/schema"
+import { eq, asc } from "drizzle-orm"
+import { redis } from "@/lib/redis"
+
+const DEFAULT_LIMIT = 20
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const verseId = searchParams.get("verseId")
+  const page = Number.parseInt(searchParams.get("page") || "1", 10)
+  const limit = Number.parseInt(searchParams.get("limit") || String(DEFAULT_LIMIT), 10)
+
+  if (!verseId) {
+    return NextResponse.json({ error: "verseId required" }, { status: 400 })
+  }
+
+  const cacheKey = `translations:${verseId}:${page}:${limit}`
+  const cached = await redis.get(cacheKey)
+  if (cached) {
+    return NextResponse.json(cached)
+  }
+
+  const data = await db.query.translations.findMany({
+    where: eq(translations.verseId, verseId),
+    orderBy: (translations, { asc }) => [asc(translations.translator)],
+    limit,
+    offset: (page - 1) * limit,
+  })
+
+  await redis.set(cacheKey, data, { ex: 60 })
+
+  return NextResponse.json(data)
+}

--- a/app/api/verses/route.test.ts
+++ b/app/api/verses/route.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const sample = [
+  { id: 'v1', bookId: 'b1', number: 1, text: 'alpha' },
+  { id: 'v2', bookId: 'b1', number: 2, text: 'beta' },
+  { id: 'v3', bookId: 'b1', number: 3, text: 'gamma' },
+]
+
+const findMany = vi.fn(({ limit, offset }) => sample.slice(offset, offset + limit))
+vi.mock('@/lib/db', () => ({
+  db: { query: { verses: { findMany } } }
+}))
+vi.mock('@/lib/schema', () => ({ translations: {}, verses: {} }))
+
+const store = new Map<string, any>()
+const get = vi.fn(async (key: string) => store.get(key))
+const set = vi.fn(async (key: string, value: any) => { store.set(key, value) })
+vi.mock('@/lib/redis', () => ({
+  redis: { get, set }
+}))
+
+const { GET } = await import('./route')
+
+beforeEach(() => {
+  store.clear()
+  vi.clearAllMocks()
+})
+
+describe('GET /api/verses', () => {
+  it('paginates results', async () => {
+    const req1 = new Request('http://test?bookId=b1&page=1&limit=2')
+    const res1 = await GET(req1)
+    const body1 = await res1.json()
+    expect(body1).toEqual(sample.slice(0, 2))
+
+    const req2 = new Request('http://test?bookId=b1&page=2&limit=2')
+    const res2 = await GET(req2)
+    const body2 = await res2.json()
+    expect(body2).toEqual(sample.slice(2, 4))
+  })
+
+  it('caches responses for identical queries', async () => {
+    const req = new Request('http://test?bookId=b1&page=1&limit=2')
+    await GET(req)
+    await GET(req)
+
+    expect(get).toHaveBeenCalledTimes(2)
+    expect(set).toHaveBeenCalledTimes(1)
+    expect(findMany).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns 400 if bookId missing', async () => {
+    const req = new Request('http://test')
+    const res = await GET(req)
+    expect(res.status).toBe(400)
+  })
+})

--- a/app/api/verses/route.ts
+++ b/app/api/verses/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { verses } from "@/lib/schema"
+import { eq, asc } from "drizzle-orm"
+import { redis } from "@/lib/redis"
+
+const DEFAULT_LIMIT = 20
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const bookId = searchParams.get("bookId")
+  const page = Number.parseInt(searchParams.get("page") || "1", 10)
+  const limit = Number.parseInt(searchParams.get("limit") || String(DEFAULT_LIMIT), 10)
+
+  if (!bookId) {
+    return NextResponse.json({ error: "bookId required" }, { status: 400 })
+  }
+
+  const cacheKey = `verses:${bookId}:${page}:${limit}`
+  const cached = await redis.get(cacheKey)
+  if (cached) {
+    return NextResponse.json(cached)
+  }
+
+  const data = await db.query.verses.findMany({
+    where: eq(verses.bookId, bookId),
+    orderBy: (verses, { asc }) => [asc(verses.number)],
+    limit,
+    offset: (page - 1) * limit,
+  })
+
+  await redis.set(cacheKey, data, { ex: 60 })
+
+  return NextResponse.json(data)
+}

--- a/app/books/[bookId]/page.tsx
+++ b/app/books/[bookId]/page.tsx
@@ -3,24 +3,28 @@ import { notFound } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { db } from "@/lib/db"
-import { books } from "@/lib/schema"
-import { eq } from "drizzle-orm"
+import { books, verses } from "@/lib/schema"
+import { eq, asc } from "drizzle-orm"
+import { VersesList } from "@/components/verses-list"
 
 export const revalidate = 60
+
+const PAGE_SIZE = 20
 
 export default async function BookPage({ params }: { params: { bookId: string } }) {
   const book = await db.query.books.findFirst({
     where: eq(books.id, params.bookId),
-    with: {
-      verses: {
-        orderBy: (verses, { asc }) => [asc(verses.number)],
-      },
-    },
   })
 
   if (!book) {
     notFound()
   }
+
+  const initialVerses = await db.query.verses.findMany({
+    where: eq(verses.bookId, params.bookId),
+    orderBy: (verses, { asc }) => [asc(verses.number)],
+    limit: PAGE_SIZE,
+  })
 
   return (
     <main className="flex min-h-screen flex-col items-center p-4 md:p-24">
@@ -51,20 +55,7 @@ export default async function BookPage({ params }: { params: { bookId: string } 
             </div>
 
             <h2 className="text-2xl font-semibold mb-4 border-t pt-4">Verses</h2>
-            <div className="space-y-3 mb-8">
-              {book.verses.map((verse) => (
-                <Card key={verse.id} className="p-4">
-                  <div className="flex justify-between items-center">
-                    <div>
-                      <span className="font-medium">Verse {verse.number}</span>
-                    </div>
-                    <Button asChild size="sm" variant="outline">
-                      <Link href={`/books/${book.id}/verses/${verse.id}`}>View Translations</Link>
-                    </Button>
-                  </div>
-                </Card>
-              ))}
-            </div>
+            <VersesList bookId={book.id} initialVerses={initialVerses} pageSize={PAGE_SIZE} />
           </div>
         </div>
       </div>

--- a/components/translations-list.tsx
+++ b/components/translations-list.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+
+interface Translation {
+  id: string
+  text: string
+  translator: string
+  language: string
+}
+
+export function TranslationsList({
+  verseId,
+  initialTranslations,
+  pageSize,
+}: {
+  verseId: string
+  initialTranslations: Translation[]
+  pageSize: number
+}) {
+  const [translations, setTranslations] = useState<Translation[]>(initialTranslations)
+  const [page, setPage] = useState(1)
+  const [loading, setLoading] = useState(false)
+  const [hasMore, setHasMore] = useState(initialTranslations.length === pageSize)
+
+  async function loadMore() {
+    setLoading(true)
+    const nextPage = page + 1
+    const res = await fetch(`/api/translations?verseId=${verseId}&page=${nextPage}&limit=${pageSize}`)
+    const data: Translation[] = await res.json()
+    setTranslations((prev) => [...prev, ...data])
+    setPage(nextPage)
+    setHasMore(data.length === pageSize)
+    setLoading(false)
+  }
+
+  return (
+    <div className="space-y-6">
+      {translations.map((translation) => (
+        <div key={translation.id} className="border-b pb-4 last:border-b-0 last:pb-0">
+          <h3 className="font-medium text-lg mb-2">Translation by {translation.translator}</h3>
+          <p className="text-gray-800 whitespace-pre-line">{translation.text}</p>
+          <p className="text-sm text-gray-500 mt-2">Language: {translation.language}</p>
+        </div>
+      ))}
+      {hasMore && (
+        <div className="flex justify-center">
+          <Button onClick={loadMore} disabled={loading} variant="outline">
+            {loading ? "Loading..." : "Load More"}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/verses-list.tsx
+++ b/components/verses-list.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Card } from "@/components/ui/card"
+
+interface Verse {
+  id: string
+  number: number
+}
+
+export function VersesList({
+  bookId,
+  initialVerses,
+  pageSize,
+}: {
+  bookId: string
+  initialVerses: Verse[]
+  pageSize: number
+}) {
+  const [verses, setVerses] = useState<Verse[]>(initialVerses)
+  const [page, setPage] = useState(1)
+  const [loading, setLoading] = useState(false)
+  const [hasMore, setHasMore] = useState(initialVerses.length === pageSize)
+
+  async function loadMore() {
+    setLoading(true)
+    const nextPage = page + 1
+    const res = await fetch(`/api/verses?bookId=${bookId}&page=${nextPage}&limit=${pageSize}`)
+    const data: Verse[] = await res.json()
+    setVerses((prev) => [...prev, ...data])
+    setPage(nextPage)
+    setHasMore(data.length === pageSize)
+    setLoading(false)
+  }
+
+  return (
+    <div className="space-y-3 mb-8">
+      {verses.map((verse) => (
+        <Card key={verse.id} className="p-4">
+          <div className="flex justify-between items-center">
+            <div>
+              <span className="font-medium">Verse {verse.number}</span>
+            </div>
+            <Button asChild size="sm" variant="outline">
+              <Link href={`/books/${bookId}/verses/${verse.id}`}>View Translations</Link>
+            </Button>
+          </div>
+        </Card>
+      ))}
+      {hasMore && (
+        <div className="flex justify-center">
+          <Button onClick={loadMore} disabled={loading} variant="outline">
+            {loading ? "Loading..." : "Load More"}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,20 +1,9 @@
-import { neon, neonConfig } from "@neondatabase/serverless"
-import { drizzle } from "drizzle-orm/neon-http"
+import { Pool } from "pg"
+import { drizzle } from "drizzle-orm/node-postgres"
 import * as schema from "./schema"
 
-// This approach doesn't use Prisma, which is causing deployment issues
-// Instead, we'll use Neon's serverless driver directly with Drizzle ORM
+const pool = new Pool({ connectionString: process.env.DATABASE_URL })
 
-// Optional: Configure neon to use WebSockets for better performance
-if (typeof WebSocket !== "undefined") {
-  neonConfig.webSocketConstructor = WebSocket
-}
+export const db = drizzle(pool, { schema })
 
-// Create a SQL executor using the Neon serverless driver
-const sql = neon(process.env.DATABASE_URL!)
-
-// Pass the schema with relations to the drizzle function
-export const db = drizzle(sql, { schema })
-
-// Export the SQL executor for direct queries
-export { sql }
+export { pool }

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -1,0 +1,27 @@
+import { Redis } from "@upstash/redis"
+
+const redisUrl = process.env.UPSTASH_REDIS_REST_URL
+const redisToken = process.env.UPSTASH_REDIS_REST_TOKEN
+
+// Fallback to in-memory store if env vars are missing
+let redis: any
+
+if (redisUrl && redisToken) {
+  redis = new Redis({
+    url: redisUrl,
+    token: redisToken,
+  })
+} else {
+  const store = new Map<string, any>()
+  redis = {
+    get: async (key: string) => store.get(key),
+    set: async (key: string, value: any, _options?: { ex?: number }) => {
+      store.set(key, value)
+    },
+    del: async (key: string) => {
+      store.delete(key)
+    },
+  }
+}
+
+export { redis }


### PR DESCRIPTION
## Summary
- switch to PostgreSQL pool with Drizzle ORM
- introduce Upstash Redis caching layer for verses and translations APIs
- add paginated lazy-loading components for verses and translations
- cover pagination, caching, and parameter validation in verses/translations API tests

## Testing
- `pnpm test`
- `pnpm run lint` *(prompts for ESLint config and exits with 1)*

------
https://chatgpt.com/codex/tasks/task_e_689477d73e84832390f76cff03a95900