### PR TITLE
feat: add basic gamification and user profile progress

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,66 @@
+import { Badge } from "@/components/ui/badge"
+import { Progress } from "@/components/ui/progress"
+import {
+  commentBadges,
+  highlightBadges,
+  getBadges,
+  progressToNextBadge,
+  calculateStreak,
+} from "@/lib/gamification"
+
+export default function ProfilePage() {
+  // Placeholder user data
+  const user = {
+    username: "Guest",
+    commentKarma: 7,
+    highlightKarma: 12,
+    activity: [
+      new Date(),
+      new Date(Date.now() - 86400000),
+      new Date(Date.now() - 2 * 86400000),
+    ],
+  }
+
+  const badges = getBadges(user)
+  const commentProgress = progressToNextBadge(user.commentKarma, commentBadges)
+  const highlightProgress = progressToNextBadge(
+    user.highlightKarma,
+    highlightBadges,
+  )
+  const streak = calculateStreak(user.activity)
+
+  return (
+    <main className="flex flex-col gap-6 p-4">
+      <h1 className="text-2xl font-bold">{user.username}'s Profile</h1>
+
+      <section>
+        <h2 className="font-semibold mb-2">Comment Karma</h2>
+        <Progress value={commentProgress} className="w-full" />
+        <p className="text-sm mt-1">{user.commentKarma} points</p>
+      </section>
+
+      <section>
+        <h2 className="font-semibold mb-2">Highlight Karma</h2>
+        <Progress value={highlightProgress} className="w-full" />
+        <p className="text-sm mt-1">{user.highlightKarma} points</p>
+      </section>
+
+      <section>
+        <h2 className="font-semibold mb-2">Badges</h2>
+        <div className="flex flex-wrap gap-2">
+          {badges.comments.map((b) => (
+            <Badge key={`c-${b}`}>{b}</Badge>
+          ))}
+          {badges.highlights.map((b) => (
+            <Badge key={`h-${b}`}>{b}</Badge>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="font-semibold mb-2">Current Streak</h2>
+        <p>{streak} days</p>
+      </section>
+    </main>
+  )
+}

--- a/lib/gamification.ts
+++ b/lib/gamification.ts
@@ -1,0 +1,81 @@
+import { users } from "./schema"
+import { eq, sql } from "drizzle-orm"
+
+export interface Badge {
+  name: string
+  requirement: number
+}
+
+export const commentBadges: Badge[] = [
+  { name: "First Comment", requirement: 1 },
+  { name: "Conversationalist", requirement: 10 },
+  { name: "Commentator", requirement: 50 },
+]
+
+export const highlightBadges: Badge[] = [
+  { name: "First Highlight", requirement: 1 },
+  { name: "Highlighter", requirement: 10 },
+  { name: "Illuminator", requirement: 50 },
+]
+
+export async function addKarma(
+  userId: string | undefined,
+  type: "comment" | "highlight",
+  points = 1,
+) {
+  if (!userId) {
+    throw new Error("userId is required")
+  }
+  const { db } = await import("./db")
+  const update =
+    type === "comment"
+      ? { commentKarma: sql`${users.commentKarma} + ${points}` }
+      : { highlightKarma: sql`${users.highlightKarma} + ${points}` }
+  const res = await db
+    .update(users)
+    .set(update)
+    .where(eq(users.id, userId))
+    .returning({ id: users.id })
+  if (res.length === 0) {
+    throw new Error(`User with id ${userId} not found`)
+  }
+  return res[0]
+}
+
+export function getBadges(user: {
+  commentKarma: number
+  highlightKarma: number
+}) {
+  return {
+    comments: commentBadges
+      .filter((b) => user.commentKarma >= b.requirement)
+      .map((b) => b.name),
+    highlights: highlightBadges
+      .filter((b) => user.highlightKarma >= b.requirement)
+      .map((b) => b.name),
+  }
+}
+
+export function progressToNextBadge(value: number, badges: Badge[]) {
+  const next = badges.find((b) => value < b.requirement)
+  if (!next) return 100
+  const index = badges.indexOf(next)
+  const prevRequirement = index > 0 ? badges[index - 1].requirement : 0
+  return ((value - prevRequirement) / (next.requirement - prevRequirement)) * 100
+}
+
+export function calculateStreak(dates: Date[]): number {
+  if (!dates.length) return 0
+  const sorted = dates
+    .map((d) => new Date(d))
+    .sort((a, b) => b.getTime() - a.getTime())
+  let streak = 1
+  for (let i = 1; i < sorted.length; i++) {
+    const diff =
+      (sorted[i - 1].setHours(0, 0, 0, 0) - sorted[i].setHours(0, 0, 0, 0)) /
+      86400000
+    if (diff === 1) streak++
+    else if (diff > 1) break
+  }
+  return streak
+}

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -8,6 +8,8 @@ export const users = pgTable("users", {
   username: text("username").notNull().unique(),
   password: text("password").notNull(),
   isGuest: boolean("is_guest").default(false).notNull(),
+  commentKarma: integer("comment_karma").default(0).notNull(),
+  highlightKarma: integer("highlight_karma").default(0).notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").notNull(),
 })

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,8 @@ model User {
   username  String   @unique
   password  String
   isGuest   Boolean  @default(false)
+  commentKarma   Int @default(0)
+  highlightKarma Int @default(0)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   

--- a/tests/gamification.test.ts
+++ b/tests/gamification.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../lib/db', () => ({
+  db: {
+    update: () => ({
+      set: () => ({
+        where: () => ({
+          returning: () => Promise.resolve([]),
+        }),
+      }),
+    }),
+  },
+}))
+
+import {
+  calculateStreak,
+  getBadges,
+  commentBadges,
+  addKarma,
+} from '../lib/gamification'
+
+describe('gamification helpers', () => {
+  it('calculates streaks correctly', () => {
+    const today = new Date()
+    const yesterday = new Date(Date.now() - 86400000)
+    const dates = [today, yesterday]
+    expect(calculateStreak(dates)).toBe(2)
+  })
+
+  it('awards comment badges based on karma', () => {
+    const badges = getBadges({ commentKarma: 10, highlightKarma: 0 })
+    expect(badges.comments).toContain(commentBadges[1].name)
+  })
+})
+
+describe('addKarma', () => {
+  it('throws for invalid user ID', async () => {
+    await expect(addKarma('invalid', 'comment')).rejects.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
- track comment and highlight karma for users
- add gamification helpers for badges and streaks
- show karma progress and badges on profile page
- validate karma updates to catch missing or unknown users

## Testing
- `pnpm test`
- `pnpm lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68947c3b0bd48323801ff3fc3560db91