### PR TITLE
Add verse view tracking and stats dashboards

### DIFF
--- a/app/api/verse-views/route.test.ts
+++ b/app/api/verse-views/route.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { POST, GET } from './route'
+
+// In-memory store to simulate verse_views table
+const verseViewsData: any[] = []
+
+// Mock the database module used in the route
+vi.mock('@/lib/db', () => ({
+  db: {
+    insert: () => ({
+      values: async (record: any) => {
+        verseViewsData.push(record)
+      }
+    }),
+    select: () => ({
+      from: () => {
+        const promise: any = Promise.resolve(verseViewsData)
+        promise.where = async (cond: any) =>
+          verseViewsData.filter((row) => row.verseId === cond.value)
+        return promise
+      }
+    })
+  }
+}))
+
+// Mock schema to satisfy module resolution
+vi.mock('@/lib/schema', () => ({ verseViews: {} }))
+
+// Simplified eq helper to return value for filtering
+vi.mock('drizzle-orm', () => ({
+  eq: (_col: any, value: any) => ({ value })
+}))
+
+beforeEach(() => {
+  verseViewsData.length = 0
+})
+
+describe('verse-views API', () => {
+  it('POST inserts verse view with translation and user', async () => {
+    const res = await POST(
+      new Request('http://test/api/verse-views', {
+        method: 'POST',
+        body: JSON.stringify({
+          verseId: 'v1',
+          translationId: 't1',
+          userId: 'u1',
+          eventType: 'view'
+        })
+      })
+    )
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.id).toBeDefined()
+    expect(verseViewsData).toHaveLength(1)
+    expect(verseViewsData[0]).toMatchObject({
+      id: json.id,
+      verseId: 'v1',
+      translationId: 't1',
+      userId: 'u1',
+      eventType: 'view'
+    })
+  })
+
+  it('POST inserts verse view without user', async () => {
+    const res = await POST(
+      new Request('http://test/api/verse-views', {
+        method: 'POST',
+        body: JSON.stringify({
+          verseId: 'v1',
+          translationId: 't2',
+          eventType: 'select'
+        })
+      })
+    )
+    const json = await res.json()
+    expect(json.id).toBeDefined()
+    expect(verseViewsData[0]).toMatchObject({
+      verseId: 'v1',
+      translationId: 't2',
+      userId: undefined,
+      eventType: 'select'
+    })
+  })
+
+  it('POST missing fields returns 400', async () => {
+    const res = await POST(
+      new Request('http://test/api/verse-views', {
+        method: 'POST',
+        body: JSON.stringify({ translationId: 't1', eventType: 'view' })
+      })
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('GET returns all records with correct shape', async () => {
+    verseViewsData.push(
+      {
+        id: '1',
+        verseId: 'v1',
+        translationId: 't1',
+        userId: 'u1',
+        eventType: 'view'
+      },
+      {
+        id: '2',
+        verseId: 'v2',
+        translationId: 't2',
+        userId: 'u2',
+        eventType: 'select'
+      }
+    )
+    const res = await GET(new Request('http://test/api/verse-views'))
+    const json = await res.json()
+    expect(json).toHaveLength(2)
+    expect(json[0]).toHaveProperty('id')
+    expect(json[0]).toHaveProperty('verseId')
+    expect(json[0]).toHaveProperty('translationId')
+    expect(json[0]).toHaveProperty('userId')
+    expect(json[0]).toHaveProperty('eventType')
+  })
+
+  it('GET filters by verseId', async () => {
+    verseViewsData.push(
+      {
+        id: '1',
+        verseId: 'v1',
+        translationId: 't1',
+        userId: 'u1',
+        eventType: 'view'
+      },
+      {
+        id: '2',
+        verseId: 'v2',
+        translationId: 't2',
+        userId: 'u2',
+        eventType: 'view'
+      }
+    )
+    const res = await GET(
+      new Request('http://test/api/verse-views?verseId=v1')
+    )
+    const json = await res.json()
+    expect(json).toHaveLength(1)
+    expect(json[0].verseId).toBe('v1')
+  })
+})
+

--- a/app/api/verse-views/route.ts
+++ b/app/api/verse-views/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server"
+import { db } from "@/lib/db"
+import { verseViews } from "@/lib/schema"
+import { eq } from "drizzle-orm"
+
+export async function POST(req: Request) {
+  const { verseId, translationId, userId, eventType } = await req.json()
+  if (!verseId || !eventType) {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 })
+  }
+  const id = crypto.randomUUID()
+  await db.insert(verseViews).values({
+    id,
+    verseId,
+    translationId,
+    userId,
+    eventType,
+  })
+  return NextResponse.json({ id })
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const verseId = searchParams.get("verseId")
+  if (verseId) {
+    const views = await db.select().from(verseViews).where(eq(verseViews.verseId, verseId))
+    return NextResponse.json(views)
+  }
+  const views = await db.select().from(verseViews)
+  return NextResponse.json(views)
+}

--- a/app/books/[bookId]/verses/[verseId]/page.tsx
+++ b/app/books/[bookId]/verses/[verseId]/page.tsx
@@ -1,23 +1,23 @@
 import Link from "next/link"
 import { notFound } from "next/navigation"
-import { prisma } from "@/lib/db"
+import { db } from "@/lib/db"
+import { verses } from "@/lib/schema"
+import { eq, asc } from "drizzle-orm"
 import { CommentSection } from "@/components/comment-section"
+import { VerseAnalytics } from "@/components/verse-analytics"
+import { TranslationAnalytics } from "@/components/translation-analytics"
 
 export default async function VersePage({
   params,
 }: {
   params: { bookId: string; verseId: string }
 }) {
-  const verse = await prisma.verse.findUnique({
-    where: {
-      id: params.verseId,
-    },
-    include: {
+  const verse = await db.query.verses.findFirst({
+    where: eq(verses.id, params.verseId),
+    with: {
       book: true,
       translations: {
-        orderBy: {
-          translator: "asc",
-        },
+        orderBy: (t, { asc }) => [asc(t.translator)],
       },
     },
   })
@@ -42,11 +42,11 @@ export default async function VersePage({
 
           <div className="space-y-6">
             {verse.translations.map((translation) => (
-              <div key={translation.id} className="border-b pb-4 last:border-b-0 last:pb-0">
-                <h3 className="font-medium text-lg mb-2">Translation by {translation.translator}</h3>
-                <p className="text-gray-800 whitespace-pre-line">{translation.text}</p>
-                <p className="text-sm text-gray-500 mt-2">Language: {translation.language}</p>
-              </div>
+              <TranslationAnalytics
+                key={translation.id}
+                translation={translation}
+                verseId={params.verseId}
+              />
             ))}
           </div>
         </div>
@@ -62,6 +62,7 @@ export default async function VersePage({
           </Link>
         </div>
       </div>
+      <VerseAnalytics verseId={params.verseId} />
     </main>
   )
 }

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,0 +1,36 @@
+import { db } from "@/lib/db"
+
+export const revalidate = 60
+
+export default async function StatsPage() {
+  const users = await db.query.users.findMany({
+    with: {
+      notes: true,
+      comments: true,
+    },
+  })
+
+  const leaderboard = users
+    .map((u) => ({
+      username: u.username,
+      contributions: u.notes.length + u.comments.length,
+    }))
+    .sort((a, b) => b.contributions - a.contributions)
+    .slice(0, 10)
+
+  return (
+    <main className="flex min-h-screen flex-col items-center p-4 md:p-24">
+      <div className="max-w-2xl w-full">
+        <h1 className="text-3xl font-bold mb-6">Contributor Leaderboard</h1>
+        <ol className="space-y-2">
+          {leaderboard.map((u, i) => (
+            <li key={u.username} className="flex justify-between border-b pb-2">
+              <span className="font-medium">{i + 1}. {u.username}</span>
+              <span className="text-sm text-gray-500">{u.contributions} contributions</span>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </main>
+  )
+}

--- a/app/users/[userId]/page.tsx
+++ b/app/users/[userId]/page.tsx
@@ -1,0 +1,57 @@
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { db } from "@/lib/db"
+import { users } from "@/lib/schema"
+import { eq } from "drizzle-orm"
+
+export default async function UserDashboard({ params }: { params: { userId: string } }) {
+  const user = await db.query.users.findFirst({
+    where: eq(users.id, params.userId),
+    with: {
+      favorites: { with: { book: true } },
+      notes: { with: { verse: { with: { book: true } } } },
+    },
+  })
+
+  if (!user) {
+    notFound()
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col items-center p-4 md:p-24">
+      <div className="max-w-3xl w-full">
+        <h1 className="text-3xl font-bold mb-6">{user.username}'s Dashboard</h1>
+
+        <section className="mb-8">
+          <h2 className="text-xl font-semibold mb-4">Highlights</h2>
+          {user.favorites.length === 0 && (
+            <p className="text-sm text-gray-500">No favorites yet.</p>
+          )}
+          <ul className="space-y-2">
+            {user.favorites.map((fav) => (
+              <li key={fav.id}>
+                <Link href={`/books/${fav.bookId}`}>{fav.book.title}</Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-4">Notes</h2>
+          {user.notes.length === 0 && (
+            <p className="text-sm text-gray-500">No notes yet.</p>
+          )}
+          <ul className="space-y-2">
+            {user.notes.map((note) => (
+              <li key={note.id}>
+                <Link href={`/books/${note.verse.bookId}/verses/${note.verseId}`}>
+                  Verse {note.verse.number} - {note.verse.book.title}
+                </Link>: {note.content}
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/components/translation-analytics.tsx
+++ b/components/translation-analytics.tsx
@@ -1,0 +1,27 @@
+"use client"
+interface Translation {
+  id: string
+  text: string
+  translator: string
+  language: string
+}
+
+export function TranslationAnalytics({ translation, verseId }: { translation: Translation; verseId: string }) {
+  function handleSelect() {
+    fetch("/api/verse-views", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ verseId, translationId: translation.id, eventType: "select" })
+    })
+  }
+  return (
+    <div
+      onClick={handleSelect}
+      className="border-b pb-4 last:border-b-0 last:pb-0 cursor-pointer"
+    >
+      <h3 className="font-medium text-lg mb-2">Translation by {translation.translator}</h3>
+      <p className="text-gray-800 whitespace-pre-line">{translation.text}</p>
+      <p className="text-sm text-gray-500 mt-2">Language: {translation.language}</p>
+    </div>
+  )
+}

--- a/components/verse-analytics.tsx
+++ b/components/verse-analytics.tsx
@@ -1,0 +1,13 @@
+"use client"
+import { useEffect } from "react"
+
+export function VerseAnalytics({ verseId }: { verseId: string }) {
+  useEffect(() => {
+    fetch("/api/verse-views", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ verseId, eventType: "view" })
+    })
+  }, [verseId])
+  return null
+}

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -109,6 +109,20 @@ export const comments = pgTable("comments", {
   updatedAt: timestamp("updated_at").notNull(),
 })
 
+// VerseViews table to track views and translation selections
+export const verseViews = pgTable("verse_views", {
+  id: text("id").primaryKey(),
+  verseId: text("verse_id")
+    .notNull()
+    .references(() => verses.id),
+  translationId: text("translation_id")
+    .references(() => translations.id),
+  userId: text("user_id")
+    .references(() => users.id),
+  eventType: text("event_type").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+})
+
 // Session table
 export const sessions = pgTable("sessions", {
   id: text("id").primaryKey(),
@@ -130,6 +144,7 @@ export const versesRelations = relations(verses, ({ one, many }) => ({
   translations: many(translations),
   notes: many(notes),
   comments: many(comments),
+  verseViews: many(verseViews),
 }))
 
 export const translationsRelations = relations(translations, ({ one, many }) => ({
@@ -138,6 +153,7 @@ export const translationsRelations = relations(translations, ({ one, many }) => 
     references: [verses.id],
   }),
   wordMappings: many(wordMappings),
+  verseViews: many(verseViews),
 }))
 
 export const usersRelations = relations(users, ({ many }) => ({
@@ -145,6 +161,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   notes: many(notes),
   comments: many(comments),
   sessions: many(sessions),
+  verseViews: many(verseViews),
 }))
 
 export const favoritesRelations = relations(favorites, ({ one }) => ({
@@ -183,6 +200,21 @@ export const commentsRelations = relations(comments, ({ one }) => ({
 export const sessionsRelations = relations(sessions, ({ one }) => ({
   user: one(users, {
     fields: [sessions.userId],
+    references: [users.id],
+  }),
+}))
+
+export const verseViewsRelations = relations(verseViews, ({ one }) => ({
+  verse: one(verses, {
+    fields: [verseViews.verseId],
+    references: [verses.id],
+  }),
+  translation: one(translations, {
+    fields: [verseViews.translationId],
+    references: [translations.id],
+  }),
+  user: one(users, {
+    fields: [verseViews.userId],
     references: [users.id],
   }),
 }))

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,10 +19,11 @@ model User {
   isGuest   Boolean  @default(false)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-  
+
   favorites Favorite[]
   notes     Note[]
   comments  Comment[]
+  verseViews VerseView[]
 }
 
 model Book {
@@ -45,10 +46,11 @@ model Verse {
   book      Book     @relation(fields: [bookId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-  
+
   translations Translation[]
   notes        Note[]
   comments     Comment[]
+  views        VerseView[]
 }
 
 model Translation {
@@ -60,8 +62,9 @@ model Translation {
   verse        Verse    @relation(fields: [verseId], references: [id])
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
-  
+
   wordMappings WordMapping[]
+  views        VerseView[]
 }
 
 model WordMapping {
@@ -107,6 +110,20 @@ model Comment {
   verse     Verse    @relation(fields: [verseId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+model VerseView {
+  id           String   @id @default(cuid())
+  verseId      String
+  verse        Verse    @relation(fields: [verseId], references: [id])
+  translationId String?
+  translation  Translation? @relation(fields: [translationId], references: [id])
+  userId       String?
+  user         User?    @relation(fields: [userId], references: [id])
+  eventType    String
+  createdAt    DateTime @default(now())
+
+  @@map("verse_views")
 }
 
 model Session {


### PR DESCRIPTION
## Summary
- track verse view and translation selections in new `verse_views` table
- expose `GET`/`POST` API for verse view tracking and hook into verse detail page
- add contributor leaderboard and personal dashboard pages
- add API tests for verse view tracking

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68947ccbaaf88323839404c52151acdb