### PR TITLE
feat: add moderation and admin protections

### DIFF
--- a/app/api/comments/[id]/delete.ts
+++ b/app/api/comments/[id]/delete.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server"
+import { promises as fs } from "fs"
+import path from "path"
+import { v4 as uuidv4 } from "uuid"
+import { getUserFromRequest } from "../../../../lib/auth"
+
+export interface Comment {
+  id: string
+  content: string
+  createdAt: string
+  votes: number
+}
+
+const COMMENTS_FILE = path.join(process.cwd(), "data", "comments.json")
+
+async function readData() {
+  try {
+    const data = await fs.readFile(COMMENTS_FILE, "utf8")
+    return JSON.parse(data || "{}") as Record<string, Comment[]>
+  } catch {
+    return {}
+  }
+}
+
+async function writeData(data: Record<string, Comment[]>) {
+  await fs.mkdir(path.dirname(COMMENTS_FILE), { recursive: true })
+  await fs.writeFile(COMMENTS_FILE, JSON.stringify(data, null, 2))
+}
+
+export function removeComment(data: Record<string, Comment[]>, commentId: string) {
+  for (const verseId of Object.keys(data)) {
+    const index = data[verseId].findIndex((c) => c.id === commentId)
+    if (index !== -1) {
+      data[verseId].splice(index, 1)
+      if (data[verseId].length === 0) delete data[verseId]
+      return true
+    }
+  }
+  return false
+}
+
+export async function DELETE(req: Request, { params }: { params: { id: string } }) {
+  const data = await readData()
+  const found = removeComment(data, params.id)
+  if (!found) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+  await writeData(data)
+
+  const user = getUserFromRequest(req)
+  const { db } = await import("../../../../lib/db")
+  const { auditLogs } = await import("../../../../lib/schema")
+  await db.insert(auditLogs).values({
+    id: uuidv4(),
+    userId: user?.id ?? null,
+    action: "comment_deleted",
+    targetType: "comment",
+    targetId: params.id,
+    createdAt: new Date(),
+  })
+
+  return NextResponse.json({ success: true })
+}

--- a/app/api/flags/[id]/route.ts
+++ b/app/api/flags/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server"
+import { db } from "../../../../lib/db"
+import { flags, auditLogs } from "../../../../lib/schema"
+import { eq } from "drizzle-orm"
+import { v4 as uuidv4 } from "uuid"
+import { getUserFromRequest } from "../../../../lib/auth"
+
+export async function DELETE(req: Request, { params }: { params: { id: string } }) {
+  const user = getUserFromRequest(req)
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+  await db.delete(flags).where(eq(flags.id, params.id))
+  await db.insert(auditLogs).values({
+    id: uuidv4(),
+    userId: user.id,
+    action: "flag_removed",
+    targetType: "flag",
+    targetId: params.id,
+    createdAt: new Date(),
+  })
+  return NextResponse.json({ success: true })
+}

--- a/app/api/flags/route.ts
+++ b/app/api/flags/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server"
+import { db } from "../../../lib/db"
+import { flags, auditLogs } from "../../../lib/schema"
+import { v4 as uuidv4 } from "uuid"
+import { getUserFromRequest } from "../../../lib/auth"
+
+export async function GET() {
+  const allFlags = await db.select().from(flags)
+  return NextResponse.json(allFlags)
+}
+
+export async function POST(req: Request) {
+  const { commentId, reason } = await req.json()
+  if (!commentId) {
+    return NextResponse.json({ error: "Missing commentId" }, { status: 400 })
+  }
+  const user = getUserFromRequest(req)
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+  const id = uuidv4()
+  await db.insert(flags).values({
+    id,
+    commentId,
+    userId: user.id,
+    reason,
+    createdAt: new Date(),
+  })
+  await db.insert(auditLogs).values({
+    id: uuidv4(),
+    userId: user.id,
+    action: "flag_created",
+    targetType: "comment",
+    targetId: commentId,
+    createdAt: new Date(),
+  })
+  return NextResponse.json({ id, commentId, reason })
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server"
+
+export interface AuthUser {
+  id: string
+  role: "user" | "admin"
+}
+
+export function getUserFromRequest(req: { headers: Headers }): AuthUser | null {
+  const id = req.headers.get("x-user-id")
+  const role = req.headers.get("x-user-role") as AuthUser["role"] | null
+  if (!id || !role) return null
+  return { id, role }
+}
+
+export function requireRole(req: NextRequest, role: AuthUser["role"]) {
+  const user = getUserFromRequest(req)
+  if (!user || user.role !== role) {
+    return NextResponse.redirect(new URL("/login", req.url))
+  }
+  return NextResponse.next()
+}
+
+export function requireAdmin(req: NextRequest) {
+  return requireRole(req, "admin")
+}

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -8,6 +8,7 @@ export const users = pgTable("users", {
   username: text("username").notNull().unique(),
   password: text("password").notNull(),
   isGuest: boolean("is_guest").default(false).notNull(),
+  role: text("role").default("user").notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").notNull(),
 })
@@ -109,6 +110,29 @@ export const comments = pgTable("comments", {
   updatedAt: timestamp("updated_at").notNull(),
 })
 
+// Flag table
+export const flags = pgTable("flags", {
+  id: text("id").primaryKey(),
+  commentId: text("comment_id")
+    .notNull()
+    .references(() => comments.id),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id),
+  reason: text("reason"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+})
+
+// Audit log table
+export const auditLogs = pgTable("audit_logs", {
+  id: text("id").primaryKey(),
+  userId: text("user_id").references(() => users.id),
+  action: text("action").notNull(),
+  targetType: text("target_type").notNull(),
+  targetId: text("target_id").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+})
+
 // Session table
 export const sessions = pgTable("sessions", {
   id: text("id").primaryKey(),
@@ -145,6 +169,8 @@ export const usersRelations = relations(users, ({ many }) => ({
   notes: many(notes),
   comments: many(comments),
   sessions: many(sessions),
+  flags: many(flags),
+  auditLogs: many(auditLogs),
 }))
 
 export const favoritesRelations = relations(favorites, ({ one }) => ({
@@ -178,6 +204,7 @@ export const commentsRelations = relations(comments, ({ one }) => ({
     fields: [comments.verseId],
     references: [verses.id],
   }),
+  flags: many(flags),
 }))
 
 export const sessionsRelations = relations(sessions, ({ one }) => ({
@@ -192,4 +219,13 @@ export const wordMappingsRelations = relations(wordMappings, ({ one }) => ({
     fields: [wordMappings.translationId],
     references: [translations.id],
   }),
+}))
+
+export const flagsRelations = relations(flags, ({ one }) => ({
+  user: one(users, { fields: [flags.userId], references: [users.id] }),
+  comment: one(comments, { fields: [flags.commentId], references: [comments.id] }),
+}))
+
+export const auditLogsRelations = relations(auditLogs, ({ one }) => ({
+  user: one(users, { fields: [auditLogs.userId], references: [users.id] }),
 }))

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server"
+import { requireAdmin } from "./lib/auth"
+
+export function middleware(req: NextRequest) {
+  if (req.nextUrl.pathname.startsWith("/admin")) {
+    return requireAdmin(req)
+  }
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ["/admin/:path*"],
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,18 +11,26 @@ datasource db {
   url = env("DATABASE_URL")
 }
 
+enum Role {
+  USER
+  ADMIN
+}
+
 model User {
   id        String   @id @default(cuid())
   email     String   @unique
   username  String   @unique
   password  String
   isGuest   Boolean  @default(false)
+  role      Role     @default(USER)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-  
+
   favorites Favorite[]
   notes     Note[]
   comments  Comment[]
+  flags     Flag[]
+  auditLogs AuditLog[]
 }
 
 model Book {
@@ -107,6 +115,27 @@ model Comment {
   verse     Verse    @relation(fields: [verseId], references: [id])
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+  flags     Flag[]
+}
+
+model Flag {
+  id        String   @id @default(cuid())
+  commentId String
+  comment   Comment @relation(fields: [commentId], references: [id])
+  userId    String
+  user      User    @relation(fields: [userId], references: [id])
+  reason    String?
+  createdAt DateTime @default(now())
+}
+
+model AuditLog {
+  id        String   @id @default(cuid())
+  userId    String?
+  user      User?    @relation(fields: [userId], references: [id])
+  action    String
+  targetType String
+  targetId  String
+  createdAt DateTime @default(now())
 }
 
 model Session {

--- a/tests/comments.test.ts
+++ b/tests/comments.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { voteComment, Comment } from '../app/api/comments/route'
+import { removeComment } from '../app/api/comments/[id]/delete'
 
 describe('voteComment', () => {
   it('increments vote count', () => {
@@ -14,5 +15,20 @@ describe('voteComment', () => {
     const data: Record<string, Comment[]> = { verse1: [] }
     const updated = voteComment(data, 'verse1', 'missing', 1)
     expect(updated).toBeNull()
+  })
+
+  it('removes a comment by id', () => {
+    const data: Record<string, Comment[]> = {
+      verse1: [{ id: 'a', content: 'hi', createdAt: '', votes: 0 }],
+    }
+    const removed = removeComment(data, 'a')
+    expect(removed).toBe(true)
+    expect(data.verse1).toBeUndefined()
+  })
+
+  it('returns false when comment to remove is missing', () => {
+    const data: Record<string, Comment[]> = { verse1: [] }
+    const removed = removeComment(data, 'missing')
+    expect(removed).toBe(false)
   })
 })

--- a/tests/flags.test.ts
+++ b/tests/flags.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { flags, auditLogs } from '../lib/schema'
+
+// Hoisted mocks
+const { insertMock, selectMock, deleteMock } = vi.hoisted(() => ({
+  insertMock: vi.fn(),
+  selectMock: vi.fn(),
+  deleteMock: vi.fn(),
+}))
+
+vi.mock('../lib/db', () => ({
+  db: {
+    insert: insertMock,
+    select: selectMock,
+    delete: deleteMock,
+  },
+}))
+
+const { getUserFromRequest } = vi.hoisted(() => ({ getUserFromRequest: vi.fn() }))
+vi.mock('../lib/auth', () => ({ getUserFromRequest }))
+
+const { uuidMock } = vi.hoisted(() => ({ uuidMock: vi.fn() }))
+vi.mock('uuid', () => ({ v4: uuidMock }))
+
+// Import after mocks are declared so they receive the mocked modules
+import { GET as getFlags, POST as postFlag } from '../app/api/flags/route'
+import { DELETE as deleteFlag } from '../app/api/flags/[id]/route'
+
+describe('Flags API', () => {
+  beforeEach(() => {
+    insertMock.mockReset()
+    selectMock.mockReset()
+    deleteMock.mockReset()
+    getUserFromRequest.mockReset()
+    uuidMock.mockReset()
+  })
+
+  it('POST /api/flags creates a flag and writes an audit log', async () => {
+    const insertCalls: any[] = []
+    insertMock.mockImplementation((table) => ({
+      values: (val: any) => {
+        insertCalls.push({ table, val })
+        return Promise.resolve()
+      },
+    }))
+    getUserFromRequest.mockReturnValue({ id: 'user1', role: 'user' })
+    uuidMock.mockReturnValueOnce('flag-1').mockReturnValueOnce('audit-1')
+
+    const req = new Request('http://localhost/api/flags', {
+      method: 'POST',
+      body: JSON.stringify({ commentId: 'comment1', reason: 'spam' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    const res = await postFlag(req)
+    const body = await res.json()
+
+    expect(body).toEqual({ id: 'flag-1', commentId: 'comment1', reason: 'spam' })
+    expect(insertCalls.length).toBe(2)
+    expect(insertCalls[0].table).toBe(flags)
+    expect(insertCalls[1].table).toBe(auditLogs)
+    expect(insertCalls[1].val).toMatchObject({
+      userId: 'user1',
+      action: 'flag_created',
+      targetType: 'comment',
+      targetId: 'comment1',
+    })
+  })
+
+  it('POST /api/flags returns 400 for missing commentId', async () => {
+    getUserFromRequest.mockReturnValue({ id: 'user1', role: 'user' })
+    const req = new Request('http://localhost/api/flags', {
+      method: 'POST',
+      body: JSON.stringify({}),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await postFlag(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('POST /api/flags returns 401 without auth', async () => {
+    getUserFromRequest.mockReturnValue(null)
+    const req = new Request('http://localhost/api/flags', {
+      method: 'POST',
+      body: JSON.stringify({ commentId: 'comment1' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await postFlag(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('GET /api/flags retrieves all flags', async () => {
+    const allFlags = [{ id: 'flag-1' }]
+    selectMock.mockReturnValue({ from: () => Promise.resolve(allFlags) })
+
+    const res = await getFlags()
+    const body = await res.json()
+    expect(body).toEqual(allFlags)
+  })
+
+  it('DELETE /api/flags/[id] removes flag and writes audit log', async () => {
+    deleteMock.mockReturnValue({ where: () => Promise.resolve() })
+    const insertCalls: any[] = []
+    insertMock.mockImplementation((table) => ({
+      values: (val: any) => {
+        insertCalls.push({ table, val })
+        return Promise.resolve()
+      },
+    }))
+    getUserFromRequest.mockReturnValue({ id: 'user1', role: 'admin' })
+    uuidMock.mockReturnValue('audit-1')
+
+    const req = new Request('http://localhost/api/flags/flag-1', { method: 'DELETE' })
+    const res = await deleteFlag(req, { params: { id: 'flag-1' } })
+    const body = await res.json()
+
+    expect(body).toEqual({ success: true })
+    expect(deleteMock).toHaveBeenCalledTimes(1)
+    expect(insertCalls.length).toBe(1)
+    expect(insertCalls[0].table).toBe(auditLogs)
+    expect(insertCalls[0].val).toMatchObject({
+      userId: 'user1',
+      action: 'flag_removed',
+      targetType: 'flag',
+      targetId: 'flag-1',
+    })
+  })
+
+  it('DELETE /api/flags/[id] returns 401 without auth', async () => {
+    getUserFromRequest.mockReturnValue(null)
+    const req = new Request('http://localhost/api/flags/flag-1', { method: 'DELETE' })
+    const res = await deleteFlag(req, { params: { id: 'flag-1' } })
+    expect(res.status).toBe(401)
+  })
+})


### PR DESCRIPTION
## Summary
- add role-based middleware and admin route protection
- enable comment deletion with audit logging
- support flag creation and removal with logs
- add tests for flag API covering creation, retrieval, deletion, and error cases

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68947ccce5dc832382215d7ee21acfc1