### PR TITLE
feat: add social meta and sharing

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,26 +1,15 @@
 import type React from "react";
-import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import { notFound } from "next/navigation";
 import { NextIntlClientProvider } from "next-intl";
 import { unstable_setRequestLocale } from "next-intl/server";
-import "../globals.css";
 import { Navigation } from "@/components/navigation";
 import { ThemeProvider } from "@/components/theme-provider";
-
-const inter = Inter({ subsets: ["latin"] })
-
-export const metadata: Metadata = {
-  title: "Zen Texts Translation Comparison",
-  description: "Compare different translations of classic Zen texts",
-    generator: 'v0.dev'
-}
 
 export function generateStaticParams() {
   return [{ locale: "en" }, { locale: "es" }];
 }
 
-export default async function RootLayout({
+export default async function LocaleLayout({
   children,
   params: { locale },
 }: {
@@ -37,15 +26,11 @@ export default async function RootLayout({
   }
 
   return (
-    <html lang={locale}>
-      <body className={`${inter.className} bg-gray-50 min-h-screen`}>
-        <NextIntlClientProvider locale={locale} messages={messages}>
-          <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-            <Navigation />
-            {children}
-          </ThemeProvider>
-        </NextIntlClientProvider>
-      </body>
-    </html>
+    <NextIntlClientProvider locale={locale} messages={messages}>
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        <Navigation />
+        {children}
+      </ThemeProvider>
+    </NextIntlClientProvider>
   );
 }

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+
+import { db } from "@/lib/db";
+import { highlights, verses } from "@/lib/schema";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get("id");
+
+  if (!id) {
+    return NextResponse.json({ error: "Missing id" }, { status: 400 });
+  }
+
+  const [highlight] = await db
+    .select()
+    .from(highlights)
+    .where(eq(highlights.id, id));
+
+  if (!highlight || !highlight.isPublic) {
+    return NextResponse.json({ error: "Highlight not found" }, { status: 404 });
+  }
+
+  const [verse] = await db
+    .select()
+    .from(verses)
+    .where(eq(verses.id, highlight.verseId));
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+  const locale = process.env.NEXT_PUBLIC_DEFAULT_LOCALE || "en";
+  const path = verse
+    ? `/books/${verse.bookId}/verses/${verse.id}`
+    : "";
+  const url = `${baseUrl}/${locale}${path}?highlight=${highlight.id}`;
+
+  return NextResponse.json({ url });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import "./globals.css";
+
+const inter = Inter({ subsets: ["latin"] });
+const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+
+export const metadata: Metadata = {
+  title: "Zen Texts Translation Comparison",
+  description: "Compare different translations of classic Zen texts",
+  openGraph: {
+    title: "Zen Texts Translation Comparison",
+    description: "Compare different translations of classic Zen texts",
+    url: baseUrl,
+    siteName: "Zen Texts Translation Comparison",
+    images: [
+      {
+        url: `${baseUrl}/placeholder.jpg`,
+        width: 1200,
+        height: 630,
+        alt: "Zen Texts Translation Comparison",
+      },
+    ],
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Zen Texts Translation Comparison",
+    description: "Compare different translations of classic Zen texts",
+    images: [`${baseUrl}/placeholder.jpg`],
+  },
+  generator: "v0.dev",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className={`${inter.className} bg-gray-50 min-h-screen`}>{children}</body>
+    </html>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "lint": "next lint",
     "start": "next start",
-    "test": "vitest run"
+    "test": "vitest run",
+    "generate-sitemap": "node scripts/generate-sitemap.js"
   },
   "dependencies": {
     "@aws-sdk/client-rds-data": "latest",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>http://localhost:3000/en/</loc></url>
+  <url><loc>http://localhost:3000/en/about</loc></url>
+  <url><loc>http://localhost:3000/en/compare</loc></url>
+  <url><loc>http://localhost:3000/en/books</loc></url>
+  <url><loc>http://localhost:3000/en/translations</loc></url>
+  <url><loc>http://localhost:3000/es/</loc></url>
+  <url><loc>http://localhost:3000/es/about</loc></url>
+  <url><loc>http://localhost:3000/es/compare</loc></url>
+  <url><loc>http://localhost:3000/es/books</loc></url>
+  <url><loc>http://localhost:3000/es/translations</loc></url>
+</urlset>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,0 +1,21 @@
+const { writeFileSync } = require('fs');
+
+const rawBase = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+const baseUrl = rawBase.endsWith('/') ? rawBase.slice(0, -1) : rawBase;
+const locales = ['en', 'es'];
+const routes = ['/', '/about', '/compare', '/books', '/translations'];
+
+const urls = [];
+for (const locale of locales) {
+  for (const route of routes) {
+    urls.push(`${baseUrl}/${locale}${route}`);
+  }
+}
+
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n` +
+  '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
+  urls.map((url) => `  <url><loc>${url}</loc></url>`).join('\n') +
+  '\n</urlset>\n';
+
+writeFileSync('public/sitemap.xml', sitemap);
+console.log('sitemap generated');


### PR DESCRIPTION
## Summary
- add OpenGraph/Twitter metadata in root layout
- implement highlight share link API
- generate sitemap via build script

## Testing
- `pnpm test`
- `node scripts/generate-sitemap.js`


------
https://chatgpt.com/codex/tasks/task_e_68948b4db520832388f9890afa24912c