### PR TITLE
feat: add Terebess PDF ingestion script

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "mysql2": "latest",
     "next": "14.2.16",
     "next-intl": "^3.7.1",
+    "pdf-parse": "^1.1.1",
     "pg": "latest",
     "postgres": "latest",
     "prisma": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       next-intl:
         specifier: ^3.7.1
         version: 3.26.5(next@14.2.16(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(react@18.0.0)
+      pdf-parse:
+        specifier: ^1.1.1
+        version: 1.1.1
       pg:
         specifier: latest
         version: 8.16.3
@@ -4223,6 +4226,9 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
+  node-ensure@0.0.0:
+    resolution: {integrity: sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==}
+
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -4428,6 +4434,10 @@ packages:
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
+
+  pdf-parse@1.1.1:
+    resolution: {integrity: sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==}
+    engines: {node: '>=6.8.1'}
 
   pg-cloudflare@1.2.7:
     resolution: {integrity: sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==}
@@ -10686,6 +10696,8 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
+  node-ensure@0.0.0: {}
+
   node-fetch@3.3.2:
     dependencies:
       data-uri-to-buffer: 4.0.1
@@ -10906,6 +10918,13 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
+
+  pdf-parse@1.1.1:
+    dependencies:
+      debug: 3.2.7
+      node-ensure: 0.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   pg-cloudflare@1.2.7:
     optional: true

--- a/scripts/ingest-terebess.ts
+++ b/scripts/ingest-terebess.ts
@@ -1,0 +1,142 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import pdf from 'pdf-parse'
+import { prisma } from '../lib/db'
+
+// Parse a PDF and return verse text along with basic parsing stats
+async function extractVerses(
+  pdfPath: string,
+): Promise<{
+  verses: Record<number, string>
+  stats: {
+    skippedLines: number
+    nonIncreasing: number
+    duplicateVerses: number
+    skippedVerseNumbers: number
+  }
+}> {
+  const data = await pdf(await fs.readFile(pdfPath))
+  const lines = data.text
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0)
+
+  const verses: Record<number, string> = {}
+  const stats = {
+    skippedLines: 0,
+    nonIncreasing: 0,
+    duplicateVerses: 0,
+    skippedVerseNumbers: 0,
+  }
+  let currentVerse: number | null = null
+  let lastVerse: number | null = null
+
+  lines.forEach((line, idx) => {
+    const match = line.match(/^(\d+)\s+(.*)/)
+    if (match) {
+      const verseNum = parseInt(match[1], 10)
+      if (lastVerse !== null) {
+        if (verseNum <= lastVerse) {
+          stats.nonIncreasing++
+          console.warn(
+            `Non-increasing or duplicate verse number ${verseNum} at line ${idx + 1} in ${pdfPath}`,
+          )
+        } else if (verseNum > lastVerse + 1) {
+          stats.skippedVerseNumbers += verseNum - lastVerse - 1
+          console.warn(
+            `Skipped verse numbers between ${lastVerse + 1} and ${verseNum - 1} before line ${idx + 1} in ${pdfPath}`,
+          )
+        }
+      }
+      if (verses[verseNum] !== undefined) {
+        stats.duplicateVerses++
+        console.warn(`Duplicate verse number ${verseNum} at line ${idx + 1} in ${pdfPath}`)
+      }
+      currentVerse = verseNum
+      verses[currentVerse] = match[2].trim()
+      lastVerse = verseNum
+    } else if (currentVerse !== null) {
+      verses[currentVerse] += ' ' + line
+    } else {
+      stats.skippedLines++
+      console.warn(
+        `Skipping line not associated with any verse at line ${idx + 1} in ${pdfPath}: "${line}"`,
+      )
+    }
+  })
+
+  return { verses, stats }
+}
+
+async function processPdf(bookId: string, translatorId: string, pdfPath: string) {
+  const { verses, stats } = await extractVerses(pdfPath)
+  if (
+    stats.skippedLines ||
+    stats.nonIncreasing ||
+    stats.duplicateVerses ||
+    stats.skippedVerseNumbers
+  ) {
+    console.warn('Parsing stats for', pdfPath, stats)
+  }
+  for (const [numberStr, text] of Object.entries(verses)) {
+    const number = Number(numberStr)
+    const verseId = `${bookId}-verse-${number}`
+
+    await prisma.$transaction(async (tx) => {
+      const verse = await tx.verse.upsert({
+        where: { id: verseId },
+        update: {},
+        create: {
+          id: verseId,
+          number,
+          bookId,
+        },
+      })
+
+      await tx.translation.upsert({
+        where: { id: `${verseId}-${translatorId}` },
+        update: { text },
+        create: {
+          id: `${verseId}-${translatorId}`,
+          text,
+          translator: translatorId,
+          verseId: verse.id,
+        },
+      })
+    })
+  }
+}
+
+async function main() {
+  const root = path.join(process.cwd(), 'public', 'pdfs')
+  let bookDirs: string[] = []
+  try {
+    bookDirs = await fs.readdir(root)
+  } catch (err) {
+    console.error('No PDFs directory found:', root)
+    return
+  }
+
+  for (const bookDirName of bookDirs) {
+    const bookDir = path.join(root, bookDirName)
+    const stat = await fs.stat(bookDir)
+    if (!stat.isDirectory()) continue
+
+    const files = await fs.readdir(bookDir)
+    for (const file of files) {
+      if (!file.endsWith('.pdf')) continue
+      const translatorId = path.basename(file, '.pdf')
+      const pdfPath = path.join(bookDir, file)
+      console.log(`Processing ${pdfPath}`)
+      await processPdf(bookDirName, translatorId, pdfPath)
+    }
+  }
+
+  await prisma.$disconnect()
+}
+
+main().catch((e) => {
+  console.error(e)
+  prisma.$disconnect().finally(() => process.exit(1))
+})
+


### PR DESCRIPTION
## Summary
- add script to ingest verse translations from Terebess PDFs
- install pdf-parse dependency
- warn about malformed or skipped verse numbers during PDF parsing

## Testing
- `pnpm test` (fails: AssertionError in tests/quotes.test.ts)
- `pnpm lint` (fails: requires ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_6895a9a5d190832388b7eedd30cba928