### PR TITLE
feat: add export utility and download endpoint

### DIFF
--- a/app/api/export/route.ts
+++ b/app/api/export/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { exportVerses, VerseTranslation, ExportFormat } from '@/lib/export'
+
+export async function POST(req: NextRequest) {
+  const { verses, format }: { verses: VerseTranslation[]; format?: ExportFormat } =
+    await req.json()
+
+  const fmt = format ?? 'json'
+  const output = exportVerses(verses, fmt)
+  const type = fmt === 'html' ? 'text/html' : 'application/json'
+  const ext = fmt === 'html' ? 'html' : 'json'
+
+  return new NextResponse(output, {
+    headers: {
+      'Content-Type': type,
+      'Content-Disposition': `attachment; filename="verses.${ext}"`,
+    },
+  })
+}

--- a/app/api/quotes/route.ts
+++ b/app/api/quotes/route.ts
@@ -55,7 +55,7 @@ async function getLocalQuote(): Promise<Quote> {
     const quotes: Quote[] = JSON.parse(raw)
     return quotes[Math.floor(Math.random() * quotes.length)]
   } catch {
-    return { text: "Be present. The rest will follow." }
+    return { text: "Be present.", author: "Unknown" }
   }
 }
 

--- a/app/compare/multi/download-button.tsx
+++ b/app/compare/multi/download-button.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+
+interface DownloadButtonProps {
+  data: any
+}
+
+export function DownloadButton({ data }: DownloadButtonProps) {
+  const handleDownload = async () => {
+    const verses: {
+      book: string
+      translator: string
+      verseNumber: number
+      text: string
+    }[] = []
+
+    for (const [book, translators] of Object.entries<any>(data.translations)) {
+      for (const [translator, items] of Object.entries<any>(translators)) {
+        for (const item of items as any[]) {
+          verses.push({
+            book,
+            translator,
+            verseNumber: item.verseNumber,
+            text: item.text,
+          })
+        }
+      }
+    }
+
+    const res = await fetch("/api/export", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ verses, format: "json" }),
+    })
+    const blob = await res.blob()
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement("a")
+    a.href = url
+    a.download = "verses.json"
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return <Button onClick={handleDownload}>Download</Button>
+}

--- a/app/compare/multi/page.tsx
+++ b/app/compare/multi/page.tsx
@@ -1,4 +1,5 @@
 import { VerseSelector } from "./verse-selector"
+import { DownloadButton } from "./download-button"
 import { getAggregatedTranslations } from "@/lib/multi-verse"
 import { prisma } from "@/lib/db"
 import { Card } from "@/components/ui/card"
@@ -41,29 +42,34 @@ export default async function MultiComparePage({
           <p className="text-sm text-red-500 mb-4">Some verse selections were invalid and have been ignored.</p>
         )}
         {data && (
-          <div className="space-y-8">
-            {data.missing.length > 0 && (
-              <p className="text-sm text-red-500">
-                Some requested verses could not be found and were omitted.
-              </p>
-            )}
-            {Object.entries(data.translations).map(([bookTitle, translators]) => (
-              <div key={bookTitle}>
-                <h2 className="text-2xl font-semibold mb-4">{bookTitle}</h2>
-                {Object.entries(translators).map(([translator, verses]) => (
-                  <div key={translator} className="mb-6">
-                    <h3 className="text-xl font-medium mb-2">{translator}</h3>
-                    {verses.map((v) => (
-                      <div key={v.verseId} className="mb-4">
-                        <p className="text-sm text-gray-600 mb-1">Verse {v.verseNumber}</p>
-                        <p>{v.text}</p>
-                      </div>
-                    ))}
-                  </div>
-                ))}
-              </div>
-            ))}
-          </div>
+          <>
+            <div className="mb-4">
+              <DownloadButton data={data} />
+            </div>
+            <div className="space-y-8">
+              {data.missing.length > 0 && (
+                <p className="text-sm text-red-500">
+                  Some requested verses could not be found and were omitted.
+                </p>
+              )}
+              {Object.entries(data.translations).map(([bookTitle, translators]) => (
+                <div key={bookTitle}>
+                  <h2 className="text-2xl font-semibold mb-4">{bookTitle}</h2>
+                  {Object.entries(translators).map(([translator, verses]) => (
+                    <div key={translator} className="mb-6">
+                      <h3 className="text-xl font-medium mb-2">{translator}</h3>
+                      {verses.map((v) => (
+                        <div key={v.verseId} className="mb-4">
+                          <p className="text-sm text-gray-600 mb-1">Verse {v.verseNumber}</p>
+                          <p>{v.text}</p>
+                        </div>
+                      ))}
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </>
         )}
       </div>
     </main>

--- a/lib/export.ts
+++ b/lib/export.ts
@@ -1,0 +1,24 @@
+export interface VerseTranslation {
+  book: string;
+  translator: string;
+  verseNumber: number;
+  text: string;
+}
+
+export type ExportFormat = 'json' | 'html';
+
+export function exportVerses(
+  verses: VerseTranslation[],
+  format: ExportFormat = 'json'
+): string {
+  if (format === 'html') {
+    const body = verses
+      .map(
+        (v) =>
+          `<div><h3>${v.book} - ${v.translator} - Verse ${v.verseNumber}</h3><p>${v.text}</p></div>`
+      )
+      .join('\n');
+    return `<!DOCTYPE html><html><body>${body}</body></html>`;
+  }
+  return JSON.stringify(verses, null, 2);
+}


### PR DESCRIPTION
## Summary
- add helper for exporting verse translations to JSON or HTML
- implement `/api/export` endpoint returning downloadable files
- add download button to multi-verse comparison page
- align quote API fallback with expected default

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68966c422a9083238d63463a04fc2388