### PR TITLE
feat: seed additional sutras and update compare page

### DIFF
--- a/app/[locale]/compare/page.tsx
+++ b/app/[locale]/compare/page.tsx
@@ -19,23 +19,35 @@ export default function ComparePage() {
                 </div>
               </Link>
             </Button>
-            <Button asChild className="h-auto py-4" variant="outline" disabled>
-              <div className="text-left">
-                <div className="font-medium">Platform Sutra</div>
-                <div className="text-sm opacity-80">Coming soon</div>
-              </div>
+            <Button asChild className="h-auto py-4">
+              <Link href="/books/platform-sutra">
+                <div className="text-left">
+                  <div className="font-medium">Platform Sutra</div>
+                  <div className="text-sm opacity-80">
+                    Compare translations of the Sixth Patriarch's teaching
+                  </div>
+                </div>
+              </Link>
             </Button>
-            <Button asChild className="h-auto py-4" variant="outline" disabled>
-              <div className="text-left">
-                <div className="font-medium">Heart Sutra</div>
-                <div className="text-sm opacity-80">Coming soon</div>
-              </div>
+            <Button asChild className="h-auto py-4">
+              <Link href="/books/heart-sutra">
+                <div className="text-left">
+                  <div className="font-medium">Heart Sutra</div>
+                  <div className="text-sm opacity-80">
+                    Compare translations of this famous Mahayana text
+                  </div>
+                </div>
+              </Link>
             </Button>
-            <Button asChild className="h-auto py-4" variant="outline" disabled>
-              <div className="text-left">
-                <div className="font-medium">Diamond Sutra</div>
-                <div className="text-sm opacity-80">Coming soon</div>
-              </div>
+            <Button asChild className="h-auto py-4">
+              <Link href="/books/diamond-sutra">
+                <div className="text-left">
+                  <div className="font-medium">Diamond Sutra</div>
+                  <div className="text-sm opacity-80">
+                    Compare translations of the Diamond Sutra
+                  </div>
+                </div>
+              </Link>
             </Button>
           </div>
         </Card>

--- a/lib/seed.ts
+++ b/lib/seed.ts
@@ -1,61 +1,77 @@
 import { db } from "./db"
-import { books, verses, translations } from "./schema"
+import { books, verses, translations as translationsTable } from "./schema"
 import { translations as translationsData } from "./translations"
 import { v4 as uuidv4 } from "uuid"
 
 export async function seedDatabase() {
   console.log("Seeding database...")
 
-  const xinxinmingData = translationsData.xinxinming
+  for (const [bookId, bookData] of Object.entries(translationsData)) {
+    const existingBook = await db.query.books.findFirst({
+      where: (b, { eq }) => eq(b.id, bookId),
+    })
 
-  // Check if book already exists
-  const existingBook = await db.query.books.findFirst({
-    where: (books, { eq }) => eq(books.title, xinxinmingData.title),
-  })
+    if (existingBook) {
+      continue
+    }
 
-  if (existingBook) {
-    console.log("Database already seeded.")
-    return
-  }
-
-  // Using a transaction to ensure all or nothing is inserted
-  await db.transaction(async (tx) => {
-    const [newBook] = await tx
-      .insert(books)
-      .values({
-        id: uuidv4(),
-        title: xinxinmingData.title,
-        description: xinxinmingData.description,
-        author: "Jianzhi Sengcan",
-        coverImage: "/xinxin-ming-cover.png",
-        updatedAt: new Date(),
-      })
-      .returning()
-
-    for (const verse of xinxinmingData.verses) {
-      const [newVerse] = await tx
-        .insert(verses)
+    await db.transaction(async (tx) => {
+      const [newBook] = await tx
+        .insert(books)
         .values({
-          id: uuidv4(),
-          number: verse.number,
-          bookId: newBook.id,
+          id: bookId,
+          title: bookData.title,
+          description: bookData.description,
+          author: bookData.author,
+          coverImage: bookData.coverImage,
           updatedAt: new Date(),
         })
         .returning()
 
-      const translationsToInsert = xinxinmingData.translators.map((translator) => ({
-        id: uuidv4(),
-        text: verse.translations[translator.name] || "Translation not available.",
-        translator: translator.name,
-        verseId: newVerse.id,
-        updatedAt: new Date(),
-      }))
+      for (const verse of bookData.verses) {
+        const verseId = `${bookId}-verse-${verse.id}`
+        const [newVerse] = await tx
+          .insert(verses)
+          .values({
+            id: verseId,
+            number: verse.id,
+            bookId: newBook.id,
+            updatedAt: new Date(),
+          })
+          .returning()
 
-      if (translationsToInsert.length > 0) {
-        await tx.insert(translations).values(translationsToInsert)
+        const translationsToInsert = [] as {
+          id: string
+          text: string
+          translator: string
+          verseId: string
+          updatedAt: Date
+        }[]
+
+        for (const translator of bookData.translators) {
+          const text = verse.lines
+            .map((line) => line.translations[translator.id])
+            .filter(Boolean)
+            .join(" ")
+            .trim()
+          if (!text) continue
+          translationsToInsert.push({
+            id: uuidv4(),
+            text,
+            translator: translator.name,
+            verseId: newVerse.id,
+            updatedAt: new Date(),
+          })
+        }
+
+        if (translationsToInsert.length > 0) {
+          await tx.insert(translationsTable).values(translationsToInsert)
+        }
       }
-    }
-  })
+    })
+
+    console.log(`Seeded book: ${bookData.title}`)
+  }
 
   console.log("Database seeded successfully!")
 }

--- a/lib/translations.ts
+++ b/lib/translations.ts
@@ -17,6 +17,7 @@ export interface Translator {
   link?: string
 }
 
+// Translators for the Xinxin Ming
 export const translators: Translator[] = [
   {
     id: "waley",
@@ -203,11 +204,44 @@ export const translators: Translator[] = [
   // Add more translators as needed
 ]
 
+// Minimal translator lists for other texts
+const platformSutraTranslators: Translator[] = [
+  {
+    id: "mcrae",
+    name: "John McRae",
+    year: "2000",
+    description: "The Platform Sutra of the Sixth Patriarch",
+    link: "https://en.wikipedia.org/wiki/John_McRae_(scholar)",
+  },
+]
+
+const heartSutraTranslators: Translator[] = [
+  {
+    id: "xuanzang",
+    name: "Xuanzang",
+    year: "649",
+    description: "Heart Sutra translation",
+    link: "https://en.wikipedia.org/wiki/Xuanzang",
+  },
+]
+
+const diamondSutraTranslators: Translator[] = [
+  {
+    id: "kumarajiva",
+    name: "Kumarajiva",
+    year: "401",
+    description: "Diamond Sutra translation",
+    link: "https://en.wikipedia.org/wiki/Kumarajiva",
+  },
+]
+
 // Export the translations data
 export const translations = {
   xinxinming: {
     title: "Xinxin Ming",
     description: "Faith in Mind",
+    author: "Jianzhi Sengcan",
+    coverImage: "/xinxin-ming-cover.png",
     translators: translators,
     verses: [
       {
@@ -229,6 +263,83 @@ export const translations = {
               waley: "Do not like, do not dislike; all will then be clear.",
               suzuki: "Only when freed from hate and love, it reveals itself fully and without disguise.",
               goddard: "Only when freed from hate and love, it reveals itself fully and without disguise.",
+            },
+          },
+        ],
+      },
+    ],
+  },
+  "platform-sutra": {
+    title: "Platform Sutra",
+    description: "Teachings of the Sixth Patriarch",
+    author: "Huineng",
+    coverImage: "/platform-sutra-cover.png",
+    translators: platformSutraTranslators,
+    verses: [
+      {
+        id: 1,
+        lines: [
+          {
+            chinese: "菩提本無樹，明鏡亦非臺。",
+            translations: {
+              mcrae:
+                "Bodhi is fundamentally without any tree; the bright mirror is also not a stand.",
+            },
+          },
+          {
+            chinese: "本來無一物，何處惹塵埃。",
+            translations: {
+              mcrae:
+                "Originally there is not a single thing—where could any dust be attracted?",
+            },
+          },
+        ],
+      },
+    ],
+  },
+  "heart-sutra": {
+    title: "Heart Sutra",
+    description: "Prajnaparamita Heart Sutra",
+    author: "Unknown",
+    coverImage: "/heart-sutra-cover.png",
+    translators: heartSutraTranslators,
+    verses: [
+      {
+        id: 1,
+        lines: [
+          {
+            chinese: "觀自在菩薩，行深般若波羅蜜多時，",
+            translations: {
+              xuanzang:
+                "Avalokiteśvara Bodhisattva, when practicing deeply the Prajñāpāramitā,",
+            },
+          },
+          {
+            chinese: "照見五蘊皆空，度一切苦厄。",
+            translations: {
+              xuanzang:
+                "Clearly saw that all five aggregates are empty, thereby transcending all suffering.",
+            },
+          },
+        ],
+      },
+    ],
+  },
+  "diamond-sutra": {
+    title: "Diamond Sutra",
+    description: "Vajracchedika Prajnaparamita Sutra",
+    author: "Unknown",
+    coverImage: "/diamond-sutra-cover.png",
+    translators: diamondSutraTranslators,
+    verses: [
+      {
+        id: 1,
+        lines: [
+          {
+            chinese: "如是我聞。一時佛在舍衛國。",
+            translations: {
+              kumarajiva:
+                "Thus have I heard. At one time the Buddha was staying in Śrāvastī.",
             },
           },
         ],


### PR DESCRIPTION
## Summary
- add Platform, Heart, and Diamond Sutra entries to translations data
- update database seed scripts to handle all books
- enable compare page buttons to link to new sutras

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: expected { Object (text) } to deeply equal { text: 'Be present.', …(1) })*

------
https://chatgpt.com/codex/tasks/task_e_68966c0222f88323b665c55a4a4408fc