### PR TITLE
Add metadata, share API, and sitemap generation

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,26 +1,15 @@
 import type React from "react";
-import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import { notFound } from "next/navigation";
 import { NextIntlClientProvider } from "next-intl";
 import { unstable_setRequestLocale } from "next-intl/server";
-import "../globals.css";
 import { Navigation } from "@/components/navigation";
 import { ThemeProvider } from "@/components/theme-provider";
-
-const inter = Inter({ subsets: ["latin"] })
-
-export const metadata: Metadata = {
-  title: "Zen Texts Translation Comparison",
-  description: "Compare different translations of classic Zen texts",
-    generator: 'v0.dev'
-}
 
 export function generateStaticParams() {
   return [{ locale: "en" }, { locale: "es" }];
 }
 
-export default async function RootLayout({
+export default async function LocaleLayout({
   children,
   params: { locale },
 }: {
@@ -37,15 +26,11 @@ export default async function RootLayout({
   }
 
   return (
-    <html lang={locale}>
-      <body className={`${inter.className} bg-gray-50 min-h-screen`}>
-        <NextIntlClientProvider locale={locale} messages={messages}>
-          <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-            <Navigation />
-            {children}
-          </ThemeProvider>
-        </NextIntlClientProvider>
-      </body>
-    </html>
+    <NextIntlClientProvider locale={locale} messages={messages}>
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        <Navigation />
+        {children}
+      </ThemeProvider>
+    </NextIntlClientProvider>
   );
 }

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get("id") || searchParams.get("highlightId");
+  if (!id) {
+    return NextResponse.json({ error: "Missing highlight id" }, { status: 400 });
+  }
+
+  const baseUrl = req.nextUrl.origin;
+  const highlightUrl = `${baseUrl}/highlights/${id}`;
+
+  const twitter = `https://twitter.com/intent/tweet?url=${encodeURIComponent(highlightUrl)}`;
+  const facebook = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(highlightUrl)}`;
+
+  return NextResponse.json({ url: highlightUrl, twitter, facebook });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,34 @@
+import type React from "react";
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import "./globals.css";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export const metadata: Metadata = {
+  title: "Zen Texts Translation Comparison",
+  description: "Compare different translations of classic Zen texts",
+  generator: "v0.dev",
+  openGraph: {
+    title: "Zen Texts Translation Comparison",
+    description: "Compare different translations of classic Zen texts",
+    url: "https://example.com",
+    siteName: "Zen Texts Translation Comparison",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Zen Texts Translation Comparison",
+    description: "Compare different translations of classic Zen texts",
+  },
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className={`${inter.className} bg-gray-50 min-h-screen`}>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "next build",
+    "build": "next build && node scripts/generate-sitemap.js",
     "dev": "next dev",
     "lint": "next lint",
     "start": "next start",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/</loc></url>
+  <url><loc>https://example.com/about</loc></url>
+  <url><loc>https://example.com/books</loc></url>
+</urlset>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,0 +1,13 @@
+const fs = require("fs");
+
+const baseUrl = process.env.SITE_URL || "https://example.com";
+const pages = ["/", "/about", "/books"];
+
+const urls = pages
+  .map((path) => `  <url><loc>${baseUrl}${path}</loc></url>`)
+  .join("\n");
+
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;
+
+fs.mkdirSync("public", { recursive: true });
+fs.writeFileSync("public/sitemap.xml", sitemap);


### PR DESCRIPTION
## Summary
- add root layout with OpenGraph/Twitter metadata for richer previews
- implement `/api/share` endpoint to build highlight share links
- generate `public/sitemap.xml` via build script

## Testing
- `npm test` *(fails: AssertionError: expected { Object (text) } to deeply equal { text: 'Be present.', …(1) })*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68966be019988323a7f63d64b75d86af