### PR TITLE
test: add API and multi-book comparison tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "lint": "next lint",
     "start": "next start",
-    "test": "vitest run",
+    "test": "vitest --run",
     "watch-pdf-cache": "tsx scripts/watch-pdf-cache.ts"
   },
   "dependencies": {

--- a/tests/multi-book-compare.test.ts
+++ b/tests/multi-book-compare.test.ts
@@ -37,4 +37,28 @@ describe('multi-book comparison', () => {
       ]
     })
   })
+
+  it('counts verses per book', async () => {
+    const SQL = await initSqlJs()
+    const db = new SQL.Database()
+    db.run(`
+      CREATE TABLE books (id TEXT PRIMARY KEY, title TEXT);
+      CREATE TABLE verses (id TEXT PRIMARY KEY, number INTEGER, book_id TEXT);
+      INSERT INTO books (id, title) VALUES ('b1','Book 1'), ('b2','Book 2');
+      INSERT INTO verses (id, number, book_id) VALUES
+        ('v1',1,'b1'), ('v2',2,'b1'),
+        ('v3',1,'b2'), ('v4',2,'b2');
+    `)
+    const res = db.exec(
+      `SELECT book_id, COUNT(*) as count FROM verses GROUP BY book_id ORDER BY book_id`
+    )
+    const counts = res[0].values.map((r) => ({
+      bookId: r[0] as string,
+      count: r[1] as number
+    }))
+    expect(counts).toEqual([
+      { bookId: 'b1', count: 2 },
+      { bookId: 'b2', count: 2 }
+    ])
+  })
 })

--- a/tests/reddit-feed.test.ts
+++ b/tests/reddit-feed.test.ts
@@ -34,6 +34,18 @@ describe('reddit feed API', () => {
     ])
   })
 
+  it('requests the Reddit JSON feed', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse)
+      } as any)
+
+    await GET()
+    expect(fetchMock).toHaveBeenCalledWith('https://www.reddit.com/r/zen.json')
+  })
+
   it('returns empty array when no posts', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: true,
@@ -82,6 +94,20 @@ describe('reddit feed API', () => {
     const res = await GET()
 
     expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error).toBe('Failed to fetch Reddit feed')
+  })
+
+  it('propagates upstream status codes', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: () => Promise.resolve({})
+    } as any)
+
+    const res = await GET()
+
+    expect(res.status).toBe(502)
     const body = await res.json()
     expect(body.error).toBe('Failed to fetch Reddit feed')
   })


### PR DESCRIPTION
## Summary
- add comprehensive tests for Reddit feed API with mocked fetch, including error handling when the upstream request fails
- expand multi-book comparison tests to seed books and aggregate verse counts
- run Vitest with `--run` in package.json

## Testing
- `pnpm test` *(fails: multiple suites and build errors)*
- `npx vitest tests/reddit-feed.test.ts tests/multi-book-compare.test.ts --run`


------
https://chatgpt.com/codex/tasks/task_e_689bd2bd1a188323b312a69b543e725e