### PR TITLE
feat: add download option to multi-verse comparison

### DIFF
--- a/app/compare/multi/download-button.tsx
+++ b/app/compare/multi/download-button.tsx
@@ -2,10 +2,40 @@
 
 import { Button } from "@/components/ui/button"
 
-interface DownloadButtonProps {
-  data: any
+export interface MultiVerseData {
+  /**
+   * Verses grouped by book title and translator.
+   * {
+   *   [bookTitle: string]: {
+   *     [translator: string]: Array<{
+   *       verseId: string
+   *       verseNumber: number
+   *       text: string
+   *     }>
+   *   }
+   * }
+   */
+  translations: {
+    [bookTitle: string]: {
+      [translator: string]: {
+        verseId: string
+        verseNumber: number
+        text: string
+      }[]
+    }
+  }
+  /** Identifiers for verses that could not be found. */
+  missing: string[]
 }
 
+interface DownloadButtonProps {
+  data: MultiVerseData
+}
+
+/**
+ * Button to download grouped verse translations as a JSON file.
+ * Accepts data keyed by book and translator along with a list of missing verse IDs.
+ */
 export function DownloadButton({ data }: DownloadButtonProps) {
   const handleDownload = async () => {
     const verses: {
@@ -15,9 +45,9 @@ export function DownloadButton({ data }: DownloadButtonProps) {
       text: string
     }[] = []
 
-    for (const [book, translators] of Object.entries<any>(data.translations)) {
-      for (const [translator, items] of Object.entries<any>(translators)) {
-        for (const item of items as any[]) {
+    for (const [book, translators] of Object.entries(data.translations)) {
+      for (const [translator, items] of Object.entries(translators)) {
+        for (const item of items) {
           verses.push({
             book,
             translator,

--- a/app/compare/multi/page.tsx
+++ b/app/compare/multi/page.tsx
@@ -1,6 +1,7 @@
 import { VerseSelector } from "./verse-selector"
 import { prisma } from "@/lib/db"
 import { Card } from "@/components/ui/card"
+import { DownloadButton, MultiVerseData } from "./download-button"
 
 export default async function MultiComparePage({
   searchParams,
@@ -25,18 +26,7 @@ export default async function MultiComparePage({
     pairs.push({ bookId: parts[0], verseId: parts[1] })
   }
 
-  let data: {
-    translations: {
-      [bookTitle: string]: {
-        [translator: string]: {
-          verseId: string
-          verseNumber: number
-          text: string
-        }[]
-      }
-    }
-    missing: string[]
-  } | null = null
+  let data: MultiVerseData | null = null
 
   if (pairs.length > 0) {
     const verseIds = pairs.map((p) => p.verseId)
@@ -48,15 +38,7 @@ export default async function MultiComparePage({
       },
     })
 
-    const translations: {
-      [bookTitle: string]: {
-        [translator: string]: {
-          verseId: string
-          verseNumber: number
-          text: string
-        }[]
-      }
-    } = {}
+    const translations: MultiVerseData["translations"] = {}
 
     for (const verse of verses) {
       const bookTitle = verse.book.title
@@ -99,6 +81,9 @@ export default async function MultiComparePage({
                 Some requested verses could not be found and were omitted.
               </p>
             )}
+            <div className="flex justify-end">
+              <DownloadButton data={data} />
+            </div>
             {Object.entries(data.translations).map(([bookTitle, translators]) => (
               <div key={bookTitle}>
                 <h2 className="text-2xl font-semibold mb-4">{bookTitle}</h2>


### PR DESCRIPTION
## Summary
- add download button to multi verse comparison page for exporting grouped translations
- group verse query results by book and translator via prisma
- document nested data structure for download button props

## Testing
- `pnpm test` *(fails: missing @radix-ui/react-slot, duplicate exports, etc.)*
- `pnpm lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_689bd2bc5ca883239b822e1ed72ecabb