### PR TITLE
feat: support multi-book verse selection

### DIFF
--- a/app/compare/multi/page.tsx
+++ b/app/compare/multi/page.tsx
@@ -7,9 +7,15 @@ export default async function MultiComparePage({
 }: {
   searchParams: { pairs?: string }
 }) {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000"
-  const res = await fetch(`${baseUrl}/api/books`)
-  const books = await res.json()
+  const books = await prisma.book.findMany({
+    orderBy: { title: "asc" },
+    include: {
+      verses: {
+        orderBy: { number: "asc" },
+        select: { id: true, number: true },
+      },
+    },
+  })
 
   const rawPairs = searchParams.pairs?.split(",") ?? []
   const pairs: { bookId: string; verseId: string }[] = []


### PR DESCRIPTION
## Summary
- fetch books directly with prisma to populate multi-verse selector
- group verse translations by book and translator

## Testing
- `pnpm test tests/multi-compare-page.test.ts tests/multi-book-compare.test.ts`
- `pnpm test` (fails: Transform failed with 1 error: Unexpected "}")

------
https://chatgpt.com/codex/tasks/task_e_689c59d276c88323945b648b65754b90