### PR TITLE
Add support for multiple sutra translations

### DIFF
--- a/app/[locale]/compare/page.tsx
+++ b/app/[locale]/compare/page.tsx
@@ -18,38 +18,18 @@ export default async function ComparePage() {
         <Card className="p-6 mb-8">
           <h2 className="text-xl font-semibold mb-4">Select a Text to Compare</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <Button asChild className="h-auto py-4">
-              <Link href="/books/xinxinming">
-                <div className="text-left">
-                  <div className="font-medium">Xinxin Ming (Faith in Mind)</div>
-                  <div className="text-sm opacity-80">Compare translations of this classic Zen poem</div>
-                </div>
-              </Link>
-            </Button>
-            <Button asChild className="h-auto py-4">
-              <Link href="/books/platform-sutra">
-                <div className="text-left">
-                  <div className="font-medium">Platform Sutra</div>
-                  <div className="text-sm opacity-80">Translations of the Sixth Patriarch's teaching</div>
-                </div>
-              </Link>
-            </Button>
-            <Button asChild className="h-auto py-4">
-              <Link href="/books/heart-sutra">
-                <div className="text-left">
-                  <div className="font-medium">Heart Sutra</div>
-                  <div className="text-sm opacity-80">The essence of Prajñāpāramitā</div>
-                </div>
-              </Link>
-            </Button>
-            <Button asChild className="h-auto py-4">
-              <Link href="/books/diamond-sutra">
-                <div className="text-left">
-                  <div className="font-medium">Diamond Sutra</div>
-                  <div className="text-sm opacity-80">A key Mahayana text on emptiness</div>
-                </div>
-              </Link>
-            </Button>
+            {allBooks.map((book) => (
+              <Button asChild className="h-auto py-4" key={book.id}>
+                <Link href={`/books/${book.id}`}>
+                  <div className="text-left">
+                    <div className="font-medium">{book.title}</div>
+                    {book.description && (
+                      <div className="text-sm opacity-80">{book.description}</div>
+                    )}
+                  </div>
+                </Link>
+              </Button>
+            ))}
           </div>
         </Card>
 

--- a/lib/seed.ts
+++ b/lib/seed.ts
@@ -1,12 +1,14 @@
 import { db } from "./db"
 import { books, verses, translations as translationsTable } from "./schema"
-import { translations as booksData } from "./translations"
+import { translations } from "./translations"
 import { v4 as uuidv4 } from "uuid"
 
 export async function seedDatabase() {
   console.log("Seeding database...")
 
-  for (const book of Object.values(booksData)) {
+  const books = Object.values(translations)
+
+  for (const book of books) {
     const existingBook = await db.query.books.findFirst({
       where: (b, { eq }) => eq(b.id, book.id),
     })

--- a/lib/translations.ts
+++ b/lib/translations.ts
@@ -190,6 +190,14 @@ export const translators: Translator[] = [
     link: "https://en.wikipedia.org/wiki/Edward_Conze",
   },
   {
+    id: "mcrae",
+    name: "John R. McRae",
+    publicationYear: 2000,
+    translatorBio: "Platform Sutra translator",
+    license: "Unknown",
+    link: "https://en.wikipedia.org/wiki/Platform_Sutra",
+  },
+  {
     id: "translator24",
     name: "Translator 24",
     publicationYear: 2024,
@@ -245,28 +253,31 @@ const platformSutraTranslators: Translator[] = [
   {
     id: "mcrae",
     name: "John R. McRae",
-    year: "2000",
-    description: "Platform Sutra translator",
+    publicationYear: 2000,
+    translatorBio: "Platform Sutra translator",
+    license: "Unknown",
     link: "https://en.wikipedia.org/wiki/Platform_Sutra",
   },
 ]
 
 const heartSutraTranslators: Translator[] = [
   {
-    id: "hs_red_pine",
+    id: "red_pine",
     name: "Red Pine",
-    year: "2004",
-    description: "Heart Sutra translator",
+    publicationYear: 2004,
+    translatorBio: "Heart Sutra translator",
+    license: "Unknown",
     link: "https://en.wikipedia.org/wiki/Red_Pine_(author)",
   },
 ]
 
 const diamondSutraTranslators: Translator[] = [
   {
-    id: "ds_conze",
+    id: "conze",
     name: "Edward Conze",
-    year: "1957",
-    description: "Diamond Sutra translator",
+    publicationYear: 1957,
+    translatorBio: "Diamond Sutra translator",
+    license: "Unknown",
     link: "https://en.wikipedia.org/wiki/Edward_Conze",
   },
 ]
@@ -303,102 +314,6 @@ export const translations: Record<string, Book> = {
                 "Only when freed from hate and love, it reveals itself fully and without disguise.",
               goddard:
                 "Only when freed from hate and love, it reveals itself fully and without disguise.",
-            },
-          },
-        ],
-      },
-    ],
-  },
-  'platform-sutra': {
-    id: "platform-sutra",
-    title: "Platform Sutra",
-    description: "Sutra of the Sixth Patriarch",
-    author: "Huineng",
-    coverImage: "/platform-sutra-cover.png",
-    translators,
-    verses: [
-      {
-        id: 1,
-        lines: [
-          {
-            chinese: "菩提本無樹，",
-            pinyin: "Pútí běn wú shù,",
-            translations: {
-              red_pine: "Bodhi is originally no tree,",
-              conze: "Bodhi originally has no tree,",
-            },
-          },
-          {
-            chinese: "明鏡亦非臺。",
-            pinyin: "Míng jìng yì fēi tái.",
-            translations: {
-              red_pine: "the bright mirror has no stand,",
-              conze: "the bright mirror is no stand,",
-            },
-          },
-          {
-            chinese: "本來無一物，",
-            pinyin: "Běnlái wú yī wù,",
-            translations: {
-              red_pine: "Buddha nature is always clean and pure,",
-              conze: "Originally there is not a single thing,",
-            },
-          },
-          {
-            chinese: "何處惹塵埃。",
-            pinyin: "Hé chù rě chén āi.",
-            translations: {
-              red_pine: "where would dust alight?",
-              conze: "Where can dust alight?",
-            },
-          },
-        ],
-      },
-    ],
-  },
-  'heart-sutra': {
-    id: "heart-sutra",
-    title: "Heart Sutra",
-    description: "Prajñāpāramitā Heart Sutra",
-    author: "",
-    coverImage: "/heart-sutra-cover.png",
-    translators,
-    verses: [
-      {
-        id: 1,
-        lines: [
-          {
-            chinese:
-              "觀自在菩薩，行深般若波羅蜜多時，照見五蘊皆空，度一切苦厄。",
-            translations: {
-              red_pine:
-                "Avalokiteshvara Bodhisattva, practicing deep prajna paramita, clearly saw that all five skandhas are empty, thus relieving all suffering and distress.",
-              conze:
-                "When Bodhisattva Avalokiteshvara was practicing the profound Prajnaparamita, he perceived that all five skandhas are empty, thereby transcending all suffering.",
-            },
-          },
-        ],
-      },
-    ],
-  },
-  'diamond-sutra': {
-    id: "diamond-sutra",
-    title: "Diamond Sutra",
-    description: "The Diamond that Cuts through Illusion",
-    author: "",
-    coverImage: "/diamond-sutra-cover.png",
-    translators,
-    verses: [
-      {
-        id: 1,
-        lines: [
-          {
-            chinese: "如是我聞。一時佛在舍衛國祇樹給孤獨園。",
-            translations: {
-              red_pine:
-                "Thus have I heard. Once the Buddha dwelt in Anathapindika's park in Jetavana at Sravasti.",
-              conze:
-                "Thus I have heard. Once upon a time the Lord dwelt at Shravasti in the Jetavana monastery of Anathapindika.",
             },
           },
         ],
@@ -447,7 +362,7 @@ export const translations: Record<string, Book> = {
             chinese:
               "觀自在菩薩，行深般若波羅蜜多時，照見五蘊皆空，度一切苦厄。",
             translations: {
-              hs_red_pine:
+              red_pine:
                 "Avalokiteshvara Bodhisattva, practicing deep prajnaparamita, clearly saw that all five skandhas are empty and was saved from all suffering.",
             },
           },
@@ -469,7 +384,7 @@ export const translations: Record<string, Book> = {
           {
             chinese: "如是我聞。",
             translations: {
-              ds_conze: "Thus have I heard.",
+              conze: "Thus have I heard.",
             },
           },
         ],
@@ -479,4 +394,4 @@ export const translations: Record<string, Book> = {
 }
 
 // Also export verses for backward compatibility
-export const verses = translations["xinxin-ming"].verses
+export const verses = translations["xinxinming"].verses

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -4,7 +4,9 @@ import { translations } from "../lib/translations"
 const prisma = new PrismaClient()
 
 async function main() {
-  for (const book of Object.values(translations)) {
+  const books = Object.values(translations)
+
+  for (const book of books) {
     const dbBook = await prisma.book.upsert({
       where: { id: book.id },
       update: {},


### PR DESCRIPTION
## Summary
- include Platform Sutra, Heart Sutra and Diamond Sutra in translation data
- update seeding scripts to iterate over all books
- render compare-page book buttons dynamically

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: Unexpected "}" in app/api/books/route.ts and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c59d28f4c832387c0a78a24735720