### PR TITLE
feat: add multi-verse comparison page

### DIFF
--- a/app/compare/multi/page.tsx
+++ b/app/compare/multi/page.tsx
@@ -1,74 +1,92 @@
-import { MultiVerseSelector } from "@/components/multi-verse-selector"
-import { db } from "@/lib/db"
-import { books, verses as versesTable, translations } from "@/lib/schema"
-import { asc, inArray } from "drizzle-orm"
+import { Card } from "@/components/ui/card"
+import { prisma } from "@/lib/db"
+import { getAggregatedTranslations, type AggregatedResult } from "@/lib/multi-verse"
+import { VerseSelector } from "./verse-selector"
+import { DownloadButton } from "./download-button"
 
-export default async function MultiComparePage({
-  searchParams,
-}: {
-  searchParams?: { verses?: string }
-}) {
-  const verseIds = searchParams?.verses?.split(",").filter(Boolean) || []
+interface PageProps {
+  searchParams?: { pairs?: string }
+}
 
-  const allBooks = await db.query.books.findMany({
-    orderBy: (books, { asc }) => [asc(books.title)],
-    with: {
+export default async function MultiComparePage({ searchParams }: PageProps) {
+  const pairsParam = searchParams?.pairs ? decodeURIComponent(searchParams.pairs) : ""
+  const pairStrings = pairsParam ? pairsParam.split(",").filter(Boolean) : []
+
+  const validPairs: { bookId: string; verseId: string }[] = []
+  const invalidPairs: string[] = []
+
+  for (const pair of pairStrings) {
+    const [bookId, verseId] = pair.split(":")
+    if (bookId && verseId) {
+      validPairs.push({ bookId, verseId })
+    } else {
+      invalidPairs.push(pair)
+    }
+  }
+
+  const books = await prisma.book.findMany({
+    orderBy: { title: "asc" },
+    include: {
       verses: {
-        orderBy: (versesTable, { asc }) => [asc(versesTable.number)],
+        orderBy: { number: "asc" },
+        select: { id: true, number: true },
       },
     },
   })
 
-  let selectedVerses: {
-    id: string
-    number: number
-    book: { id: string; title: string }
-    translations: { id: string; translator: string; text: string }[]
-  }[] = []
-
-  if (verseIds.length > 0) {
-    selectedVerses = await db.query.verses.findMany({
-      where: inArray(versesTable.id, verseIds),
-      with: {
-        book: true,
-        translations: {
-          orderBy: (translations, { asc }) => [asc(translations.translator)],
-        },
-      },
-    })
-
-    selectedVerses.sort(
-      (a, b) => a.book.title.localeCompare(b.book.title) || a.number - b.number,
-    )
+  let data: AggregatedResult = { translations: {}, missing: [] }
+  if (validPairs.length > 0) {
+    data = await getAggregatedTranslations(validPairs)
   }
+
+  const hasResults = Object.keys(data.translations).length > 0
 
   return (
     <main className="flex min-h-screen flex-col items-center p-4 md:p-24">
-      <div className="max-w-4xl w-full">
-        <h1 className="text-3xl font-bold mb-6">Compare Multiple Verses</h1>
+      <div className="max-w-4xl w-full space-y-6">
+        <h1 className="text-3xl font-bold">Compare Multiple Verses</h1>
 
-        <MultiVerseSelector books={allBooks} initialSelected={verseIds} />
+        <Card className="p-6">
+          <VerseSelector
+            books={books}
+            initialPairs={validPairs.length > 0 ? validPairs : undefined}
+          />
+        </Card>
 
-        <div className="space-y-8">
-          {selectedVerses.map((verse) => (
-            <div key={verse.id}>
-              <h2 className="text-xl font-semibold mb-4">
-                {verse.book.title} - Verse {verse.number}
-              </h2>
-              <div className="space-y-4">
-                {verse.translations.map((t) => (
-                  <div
-                    key={t.id}
-                    className="border-b pb-4 last:border-b-0 last:pb-0"
-                  >
-                    <h3 className="font-medium">{t.translator}</h3>
-                    <p className="whitespace-pre-line">{t.text}</p>
-                  </div>
-                ))}
-              </div>
+        {invalidPairs.length > 0 && (
+          <p className="text-red-500">Some verse selections were invalid.</p>
+        )}
+        {data.missing.length > 0 && (
+          <p className="text-red-500">Some requested verses could not be found.</p>
+        )}
+
+        {hasResults && (
+          <>
+            <div>
+              <DownloadButton data={data} />
             </div>
-          ))}
-        </div>
+            <div className="space-y-8">
+              {Object.entries(data.translations).map(([bookTitle, translators]) => (
+                <div key={bookTitle}>
+                  <h2 className="text-xl font-semibold mb-2">{bookTitle}</h2>
+                  {Object.entries(translators).map(([translator, verses]) => (
+                    <div key={translator} className="mb-4">
+                      <h3 className="font-medium">{translator}</h3>
+                      <div className="space-y-2">
+                        {verses.map((v) => (
+                          <div key={v.verseId}>
+                            <p className="font-semibold">Verse {v.verseNumber}</p>
+                            <p className="whitespace-pre-line">{v.text}</p>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </>
+        )}
       </div>
     </main>
   )

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,5 +1,6 @@
 import { Pool } from "pg"
 import { drizzle } from "drizzle-orm/node-postgres"
+import { PrismaClient } from "@prisma/client"
 import * as schema from "./schema"
 
 // Create a connection pool to a PostgreSQL database
@@ -11,6 +12,11 @@ const pool = new Pool({
 
 // Pass the schema with relations to the drizzle function
 export const db = drizzle(pool, { schema })
+
+// Initialize and export a Prisma client alongside Drizzle for parts of the
+// codebase that still rely on Prisma's API. This allows modules to import
+// `{ prisma }` from this file while others continue using the Drizzle `db`.
+export const prisma = new PrismaClient()
 
 // Export the pool for direct queries or debugging
 export { pool }


### PR DESCRIPTION
## Summary
- support selecting multiple book/verse pairs for comparison
- aggregate translations by book and translator and expose download option
- export prisma client alongside existing Drizzle db

## Testing
- `pnpm lint` *(fails: Parsing error: Declaration or statement expected.)*
- `pnpm test` *(fails: Transform failed with 1 error: /workspace/Zen-Multi-Translation-Comparison-UI/app/api/books/route.ts:28:0: ERROR: Unexpected "}")*

------
https://chatgpt.com/codex/tasks/task_e_689db73e75708323a378530b3dbb18fe