### PR TITLE
test: resolve translation API merge conflicts

### DIFF
--- a/app/api/translations/route.ts
+++ b/app/api/translations/route.ts
@@ -1,10 +1,6 @@
 import { NextResponse } from "next/server"
 import { db } from "@/lib/db"
 import { translations } from "@/lib/schema"
-<<<<<<< HEAD
-import { eq, asc } from "drizzle-orm"
-import { redis } from "../../../lib/redis"
-=======
 import { eq } from "drizzle-orm"
 import { Redis } from "@upstash/redis"
 
@@ -14,36 +10,17 @@ try {
 } catch {
   redis = null
 }
->>>>>>> origin/codex/integrate-postgresql-and-update-db.ts
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url)
   const verseId = searchParams.get("verseId")
-<<<<<<< HEAD
-  const page = Number.parseInt(searchParams.get("page") || "1", 10)
-  const limit = Number.parseInt(searchParams.get("limit") || "5", 10)
-  const offset = (page - 1) * limit
-=======
   const page = parseInt(searchParams.get("page") || "0")
   const limit = parseInt(searchParams.get("limit") || "5")
->>>>>>> origin/codex/integrate-postgresql-and-update-db.ts
 
   if (!verseId) {
     return NextResponse.json({ error: "Missing verseId" }, { status: 400 })
   }
 
-<<<<<<< HEAD
-  if (
-    !Number.isInteger(page) ||
-    page < 1 ||
-    !Number.isInteger(limit) ||
-    limit < 1
-  ) {
-    return NextResponse.json({ error: "Invalid pagination" }, { status: 400 })
-  }
-
-=======
->>>>>>> origin/codex/integrate-postgresql-and-update-db.ts
   const cacheKey = `translations:${verseId}:${page}:${limit}`
   if (redis) {
     const cached = await redis.get(cacheKey)
@@ -52,22 +29,12 @@ export async function GET(req: Request) {
     }
   }
 
-<<<<<<< HEAD
-  const data = await db
-    .select()
-    .from(translations)
-    .where(eq(translations.verseId, verseId))
-    .orderBy(asc(translations.translator))
-    .limit(limit)
-    .offset(offset)
-=======
   const data = await db.query.translations.findMany({
     where: eq(translations.verseId, verseId),
     orderBy: (translations, { asc }) => [asc(translations.translator)],
     limit,
     offset: page * limit,
   })
->>>>>>> origin/codex/integrate-postgresql-and-update-db.ts
 
   if (redis) {
     await redis.set(cacheKey, data, { ex: 60 })
@@ -75,3 +42,4 @@ export async function GET(req: Request) {
 
   return NextResponse.json(data)
 }
+

--- a/tests/translations.test.ts
+++ b/tests/translations.test.ts
@@ -1,78 +1,3 @@
-<<<<<<< HEAD
-import { describe, it, expect, vi, afterEach } from 'vitest'
-
-const translationsData = [
-  { id: 't1', verseId: 'v1', translator: 'A', text: 'ta' },
-  { id: 't2', verseId: 'v1', translator: 'B', text: 'tb' },
-  { id: 't3', verseId: 'v1', translator: 'C', text: 'tc' },
-]
-
-describe('translations route', () => {
-  afterEach(() => {
-    vi.resetModules()
-    vi.restoreAllMocks()
-  })
-
-  const mockDb = () => ({
-    db: {
-      select: vi.fn(() => ({
-        from: () => ({
-          where: () => ({
-            orderBy: () => ({
-              limit: (l: number) => ({
-                offset: (o: number) => Promise.resolve(translationsData.slice(o, o + l)),
-              }),
-            }),
-          }),
-        }),
-      })),
-    },
-  })
-
-  it('returns paginated translations and caches result', async () => {
-    const get = vi.fn().mockResolvedValue(null)
-    const set = vi.fn()
-    vi.doMock('@/lib/redis', () => ({ redis: { get, set } }))
-    vi.doMock('@/lib/db', mockDb)
-    vi.doMock('@/lib/schema', () => ({ translations: {} }))
-    const { GET } = await import('../app/api/translations/route')
-    const res = await GET(new Request('http://test?verseId=v1&page=2&limit=1'))
-    const json = await res.json()
-    expect(json).toEqual(translationsData.slice(1, 2))
-    expect(set).toHaveBeenCalledWith('translations:v1:2:1', translationsData.slice(1, 2), { ex: 60 })
-  })
-
-  it('returns cached translations', async () => {
-    const cached = translationsData.slice(0, 1)
-    const get = vi.fn().mockResolvedValue(cached)
-    const set = vi.fn()
-    vi.doMock('@/lib/redis', () => ({ redis: { get, set } }))
-    vi.doMock('@/lib/db', mockDb)
-    vi.doMock('@/lib/schema', () => ({ translations: {} }))
-    const { GET } = await import('../app/api/translations/route')
-    const res = await GET(new Request('http://test?verseId=v1&page=1&limit=1'))
-    expect(await res.json()).toEqual(cached)
-    expect(get).toHaveBeenCalled()
-    expect(set).not.toHaveBeenCalled()
-  })
-
-  it('validates missing verseId', async () => {
-    vi.doMock('@/lib/redis', () => ({ redis: undefined }))
-    vi.doMock('@/lib/db', mockDb)
-    vi.doMock('@/lib/schema', () => ({ translations: {} }))
-    const { GET } = await import('../app/api/translations/route')
-    const res = await GET(new Request('http://test'))
-    expect(res.status).toBe(400)
-  })
-
-  it('rejects invalid pagination', async () => {
-    vi.doMock('@/lib/redis', () => ({ redis: undefined }))
-    vi.doMock('@/lib/db', mockDb)
-    vi.doMock('@/lib/schema', () => ({ translations: {} }))
-    const { GET } = await import('../app/api/translations/route')
-    const res = await GET(new Request('http://test?verseId=v1&page=abc'))
-    expect(res.status).toBe(400)
-=======
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 let GET: any
@@ -129,6 +54,6 @@ describe('translations API', () => {
     const res = await GET(new Request('http://test/translations?verseId=v1&page=10&limit=2'))
     const data = await res.json()
     expect(data).toEqual([])
->>>>>>> origin/codex/integrate-postgresql-and-update-db.ts
   })
 })
+


### PR DESCRIPTION
### **User description**
## Summary
- replace conflicted `tests/translations.test.ts` with a single implementation using vitest mocks
- align `app/api/translations/route.ts` with Upstash Redis and Drizzle query API

## Testing
- `npm test` *(fails: missing modules and unresolved conflicts in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b61a602bf88323915c93b239db35bf


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Resolve Git merge conflicts in translations API

- Standardize on Upstash Redis and Drizzle query API

- Clean up test file with single vitest implementation

- Remove duplicate pagination validation logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Merge Conflicts"] --> B["Clean API Route"]
  A --> C["Unified Test File"]
  B --> D["Upstash Redis"]
  B --> E["Drizzle Query API"]
  C --> F["Vitest Mocks"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Clean up merge conflicts and standardize APIs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/api/translations/route.ts

<ul><li>Remove Git merge conflict markers and duplicate code<br> <li> Standardize on Upstash Redis implementation<br> <li> Use Drizzle query API instead of select builder<br> <li> Remove redundant pagination validation</ul>


</details>


  </td>
  <td><a href="https://github.com/aaron-makowski/Zen-Multi-Translation-Comparison-UI/pull/108/files#diff-4c72a4506755980bbd16c6c1bf266541745562094f7e33f47206438660cc2610">+45/-77</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>translations.test.ts</strong><dd><code>Resolve test file merge conflicts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/translations.test.ts

<ul><li>Remove Git merge conflict markers<br> <li> Keep single test implementation using vitest mocks<br> <li> Maintain test coverage for pagination and caching<br> <li> Use consistent mock setup with beforeEach/afterEach</ul>


</details>


  </td>
  <td><a href="https://github.com/aaron-makowski/Zen-Multi-Translation-Comparison-UI/pull/108/files#diff-867a554abe322eebc27ee1197fa569414cb1eb785e2817d7aef8441949fa44ee">+59/-134</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

