### PR TITLE
Fix bookmarks API to use file storage

### DIFF
--- a/app/api/bookmarks/route.ts
+++ b/app/api/bookmarks/route.ts
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 import { NextResponse } from "next/server"
 import { promises as fs } from "fs"
 import path from "path"
@@ -46,35 +45,4 @@ export async function DELETE(req: Request) {
   data = data.filter((id) => id !== verseId)
   await writeData(data)
   return NextResponse.json({ verseId })
-=======
-import { NextResponse } from "next/server";
-import { db } from "@/lib/db";
-import { favorites } from "@/lib/schema";
-import { eq, and } from "drizzle-orm";
-import { v4 as uuid } from "uuid";
-
-const USER_ID = "demo-user";
-
-export async function POST(req: Request) {
-  const { bookId } = await req.json();
-  if (!bookId) {
-    return NextResponse.json({ error: "bookId required" }, { status: 400 });
-  }
-  await db
-    .insert(favorites)
-    .values({ id: uuid(), userId: USER_ID, bookId })
-    .onConflictDoNothing();
-  return NextResponse.json({ success: true });
-}
-
-export async function DELETE(req: Request) {
-  const { bookId } = await req.json();
-  if (!bookId) {
-    return NextResponse.json({ error: "bookId required" }, { status: 400 });
-  }
-  await db
-    .delete(favorites)
-    .where(and(eq(favorites.userId, USER_ID), eq(favorites.bookId, bookId)));
-  return NextResponse.json({ success: true });
->>>>>>> origin/codex/create-tags-table-and-many-to-many-relation
 }


### PR DESCRIPTION
## Summary
- resolve merge conflict in bookmarks API
- keep file-based bookmarks implementation

## Testing
- `npm test` (fails: Failed to resolve import "@playwright/test")
- `npx vitest run app/api/bookmarks/route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b61a61ada0832389ea0f6c38edd287