### PR TITLE
Unify multi-compare query param to ids

### DIFF
--- a/app/compare/multi/page.test.tsx
+++ b/app/compare/multi/page.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderToString } from 'react-dom/server';
 
+;(globalThis as any).React = React;
+
 const { booksFindMany, versesFindMany } = vi.hoisted(() => ({
   booksFindMany: vi.fn(),
   versesFindMany: vi.fn(),
@@ -19,6 +21,8 @@ vi.mock('@/lib/db', () => ({
     },
   },
 }));
+
+vi.mock('@/lib/schema', () => ({ verses: {} }));
 
 import MultiComparePage from './page';
 
@@ -64,7 +68,7 @@ describe('MultiComparePage', () => {
       },
     ]);
 
-    const jsx = await MultiComparePage({ searchParams: { ids: ['v1', 'v2'] } });
+    const jsx = await MultiComparePage({ searchParams: { ids: 'v1,v2' } });
     const html = renderToString(jsx);
 
     expect(html).toContain('Book One<!-- --> - Verse <!-- -->1');
@@ -87,7 +91,7 @@ describe('MultiComparePage', () => {
   it('handles invalid ids', async () => {
     versesFindMany.mockResolvedValue([]);
 
-    const jsx = await MultiComparePage({ searchParams: { ids: ['bad'] } });
+    const jsx = await MultiComparePage({ searchParams: { ids: 'bad' } });
     const html = renderToString(jsx);
 
     expect(versesFindMany).toHaveBeenCalled();

--- a/app/compare/multi/page.tsx
+++ b/app/compare/multi/page.tsx
@@ -18,12 +18,12 @@ export default async function MultiComparePage({
     },
   })
 
-  // Normalize the ids search param into an array
+  // Normalize the ids search param into an array, supporting comma-separated values
   const idsParam = searchParams?.ids
   const verseIds = Array.isArray(idsParam)
-    ? idsParam
-    : idsParam
-    ? [idsParam]
+    ? idsParam.flatMap((v) => v.split(",").filter(Boolean))
+    : typeof idsParam === "string"
+    ? idsParam.split(",").filter(Boolean)
     : []
 
   // Fetch selected verses with their translations

--- a/app/compare/multi/verse-selector.tsx
+++ b/app/compare/multi/verse-selector.tsx
@@ -45,9 +45,9 @@ export function VerseSelector({ books, initialPairs = [{ bookId: books[0]?.id ??
     e.preventDefault()
     const query = pairs
       .filter((p) => p.bookId && p.verseId)
-      .map((p) => `${p.bookId}:${p.verseId}`)
+      .map((p) => p.verseId)
       .join(",")
-    router.push(`/compare/multi?pairs=${encodeURIComponent(query)}`)
+    router.push(`/compare/multi?ids=${encodeURIComponent(query)}`)
   }
 
   return (

--- a/components/multi-verse-selector.tsx
+++ b/components/multi-verse-selector.tsx
@@ -54,7 +54,7 @@ export function MultiVerseSelector({ books, initialSelected }: MultiVerseSelecto
 
   const handleCompare = () => {
     if (selected.length > 0) {
-      router.push(`/compare/multi?verses=${selected.join(",")}`)
+      router.push(`/compare/multi?ids=${selected.join(",")}`)
     }
   }
 

--- a/tests/multi-compare-page.test.ts
+++ b/tests/multi-compare-page.test.ts
@@ -1,98 +1,92 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 
 ;(globalThis as any).React = React
 
+const { booksFindMany, versesFindMany } = vi.hoisted(() => ({
+  booksFindMany: vi.fn(),
+  versesFindMany: vi.fn(),
+}))
+
 vi.mock('@/components/ui/card', () => ({
-  Card: ({ children }: any) => React.createElement('div', { 'data-testid': 'card' }, children)
+  Card: ({ children }: any) =>
+    React.createElement('div', { 'data-testid': 'card' }, children),
 }))
 
 vi.mock('../app/compare/multi/verse-selector', () => ({
-  VerseSelector: () => React.createElement('div', { 'data-testid': 'selector' })
+  VerseSelector: () => React.createElement('div', { 'data-testid': 'selector' }),
 }))
 
 vi.mock('@/lib/db', () => ({
-  prisma: {
-    book: { findMany: vi.fn() },
-    verse: { findMany: vi.fn() }
-  }
+  db: {
+    query: {
+      books: { findMany: booksFindMany },
+      verses: { findMany: versesFindMany },
+    },
+  },
 }))
 
+vi.mock('@/lib/schema', () => ({ verses: {} }))
+
 import MultiComparePage from '../app/compare/multi/page'
-import { prisma } from '@/lib/db'
 
 describe('MultiComparePage', () => {
+  beforeEach(() => {
+    booksFindMany.mockReset()
+    versesFindMany.mockReset()
+  })
+
   it('renders grouped translations for valid selections', async () => {
-    ;(prisma.book.findMany as any).mockResolvedValue([])
-    ;(prisma.verse.findMany as any).mockResolvedValue([
+    booksFindMany.mockResolvedValue([])
+    versesFindMany.mockResolvedValue([
       {
         id: 'v1',
         number: 1,
         book: { title: 'Book One' },
         translations: [
           { translator: 'T1', text: 'text1' },
-          { translator: 'T2', text: 'text2' }
-        ]
+          { translator: 'T2', text: 'text2' },
+        ],
       },
       {
         id: 'v2',
         number: 2,
         book: { title: 'Book Two' },
-        translations: [{ translator: 'T1', text: 'text3' }]
-      }
+        translations: [{ translator: 'T1', text: 'text3' }],
+      },
     ])
 
     const html = renderToStaticMarkup(
-      await MultiComparePage({ searchParams: { pairs: 'b1:v1,b2:v2' } })
+      await MultiComparePage({ searchParams: { ids: 'v1,v2' } })
     )
 
-    expect(html).toContain('Book One')
-    expect(html).toContain('Book Two')
-    expect(html).toMatch(/Book One.*T1.*Verse\s*1.*text1/)
-    expect(html).toMatch(/Book One.*T2.*Verse\s*1.*text2/)
-    expect(html).toMatch(/Book Two.*T1.*Verse\s*2.*text3/)
-    expect(html).not.toContain('Some requested verses could not be found')
-    expect(html).not.toContain('Some verse selections were invalid')
+    expect(html).toContain('Book One - Verse 1')
+    expect(html).toContain('Book Two - Verse 2')
+    expect(html).toContain('T1')
+    expect(html).toContain('text1')
+    expect(html).toContain('T2')
+    expect(html).toContain('text2')
+    expect(html).toContain('text3')
   })
 
-  it('shows invalid selection message when pairs malformed', async () => {
-    ;(prisma.book.findMany as any).mockResolvedValue([])
-    ;(prisma.verse.findMany as any).mockResolvedValue([
+  it('handles missing verses gracefully', async () => {
+    booksFindMany.mockResolvedValue([])
+    versesFindMany.mockResolvedValue([
       {
         id: 'v1',
         number: 1,
         book: { title: 'Book One' },
-        translations: [{ translator: 'T1', text: 'text1' }]
-      }
+        translations: [{ translator: 'T1', text: 'text1' }],
+      },
     ])
 
     const html = renderToStaticMarkup(
-      await MultiComparePage({ searchParams: { pairs: 'b1:v1,bad' } })
+      await MultiComparePage({ searchParams: { ids: 'v1,v2' } })
     )
 
-    expect(html).toContain('Some verse selections were invalid')
     expect(html).toContain('Book One')
-    expect(html).toContain('text1')
-  })
-
-  it('shows missing verse message when verse not found', async () => {
-    ;(prisma.book.findMany as any).mockResolvedValue([])
-    ;(prisma.verse.findMany as any).mockResolvedValue([
-      {
-        id: 'v1',
-        number: 1,
-        book: { title: 'Book One' },
-        translations: [{ translator: 'T1', text: 'text1' }]
-      }
-    ])
-
-    const html = renderToStaticMarkup(
-      await MultiComparePage({ searchParams: { pairs: 'b1:v1,b2:v2' } })
-    )
-
-    expect(html).toContain('Some requested verses could not be found')
-    expect(html).toContain('Book One')
-    expect(html).toContain('text1')
+    expect(html).not.toContain('Book Two')
   })
 })
+


### PR DESCRIPTION
### **User description**
## Summary
- Parse comma-separated `ids` for multi-verse comparison
- Generate `ids` URLs from verse selector components
- Update tests to use `ids` parameter

## Testing
- `npx vitest run tests/multi-compare-page.test.ts app/compare/multi/page.test.tsx`
- `pnpm test` *(fails: Failed to resolve import "@playwright/test" and other unrelated errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b61a9e50d48323b774899984ded2f6


___

### **PR Type**
Enhancement


___

### **Description**
- Unify multi-compare query parameter from `pairs` to `ids`

- Support comma-separated verse IDs in URL format

- Update verse selector components to generate `ids` URLs

- Refactor tests to use new parameter structure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old pairs format"] --> B["Parse comma-separated ids"]
  B --> C["Generate ids URLs"]
  C --> D["Updated multi-compare page"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>multi-compare-page.test.ts</strong><dd><code>Update tests for ids parameter format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/multi-compare-page.test.ts

<ul><li>Replace <code>pairs</code> parameter with <code>ids</code> in test cases<br> <li> Update mock structure to use <code>db.query</code> instead of <code>prisma</code><br> <li> Simplify test assertions for new parameter format<br> <li> Add proper mock reset in beforeEach hook</ul>


</details>


  </td>
  <td><a href="https://github.com/aaron-makowski/Zen-Multi-Translation-Comparison-UI/pull/115/files#diff-4a68d96d59cd5544f4d673ad5ebe361d7dd26f9d66dbc1892483cdac7c764e34">+92/-98</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.test.tsx</strong><dd><code>Refactor page tests for comma-separated ids</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/compare/multi/page.test.tsx

<ul><li>Change test parameter from array to comma-separated string<br> <li> Add React global and schema mock<br> <li> Update test cases to use <code>ids: 'v1,v2'</code> format</ul>


</details>


  </td>
  <td><a href="https://github.com/aaron-makowski/Zen-Multi-Translation-Comparison-UI/pull/115/files#diff-62e9d8de15461ec9bb3e4bada0a438a07446440469d41746b8512f718d8793ff">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Parse comma-separated ids parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/compare/multi/page.tsx

<ul><li>Parse comma-separated <code>ids</code> parameter into array<br> <li> Support both string and array formats with flatMap<br> <li> Handle comma splitting and filtering of empty values</ul>


</details>


  </td>
  <td><a href="https://github.com/aaron-makowski/Zen-Multi-Translation-Comparison-UI/pull/115/files#diff-00961de974f17a7fa2d483c6a01ec3401edec3d50278ba078d32a67fde88ce58">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>verse-selector.tsx</strong><dd><code>Generate ids URLs from verse selector</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/compare/multi/verse-selector.tsx

<ul><li>Generate URLs with <code>ids</code> parameter instead of <code>pairs</code><br> <li> Extract verse IDs directly from pairs<br> <li> Update form submission to use new URL format</ul>


</details>


  </td>
  <td><a href="https://github.com/aaron-makowski/Zen-Multi-Translation-Comparison-UI/pull/115/files#diff-440cdf9f0ed954ce898c937a5e25ac46ead706b456da2143b5ec89318de771ec">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>multi-verse-selector.tsx</strong><dd><code>Update multi-verse selector URL generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/multi-verse-selector.tsx

<ul><li>Change URL generation from <code>verses</code> to <code>ids</code> parameter<br> <li> Update handleCompare function to use new parameter name</ul>


</details>


  </td>
  <td><a href="https://github.com/aaron-makowski/Zen-Multi-Translation-Comparison-UI/pull/115/files#diff-543a4b3ab7d11e37c330fbf84c3d0fd9f4abbdd9af44fd86a914de5a6f61030e">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

