### PR TITLE
Use root redis import in verses route

### DIFF
--- a/app/api/verses/route.ts
+++ b/app/api/verses/route.ts
@@ -2,33 +2,17 @@ import { NextResponse } from "next/server"
 import { db } from "@/lib/db"
 import { verses } from "@/lib/schema"
 import { eq } from "drizzle-orm"
-<<<<<<< HEAD
 import { redis } from "@/lib/redis"
 
 export async function GET(req: Request) {
-=======
-import { redis } from "../../../lib/redis"
-
-export async function GET(req: Request) {
->>>>>>> origin/main
   const { searchParams } = new URL(req.url)
   const bookId = searchParams.get("bookId")
   const page = Number.parseInt(searchParams.get("page") || "1", 10)
   const limit = Number.parseInt(searchParams.get("limit") || "10", 10)
   const offset = (page - 1) * limit
-<<<<<<< HEAD
-
   if (!bookId) {
     return NextResponse.json({ error: "Missing bookId" }, { status: 400 })
   }
-
-=======
-
-  if (!bookId) {
-    return NextResponse.json({ error: "Missing bookId" }, { status: 400 })
-  }
-
->>>>>>> origin/main
   if (
     !Number.isInteger(page) ||
     page < 1 ||
@@ -37,8 +21,6 @@ export async function GET(req: Request) {
   ) {
     return NextResponse.json({ error: "Invalid pagination" }, { status: 400 })
   }
-<<<<<<< HEAD
-
   const cacheKey = `verses:${bookId}:${page}:${limit}`
   if (redis) {
     const cached = await redis.get(cacheKey)
@@ -46,37 +28,15 @@ export async function GET(req: Request) {
       return NextResponse.json(cached)
     }
   }
-
-=======
-  const cacheKey = `verses:${bookId}:${page}:${limit}`
-  if (redis) {
-    const cached = await redis.get(cacheKey)
-    if (cached) {
-      return NextResponse.json(cached)
-    }
-  }
-
->>>>>>> origin/main
   const data = await db.query.verses.findMany({
     where: eq(verses.bookId, bookId),
     orderBy: (verses, { asc }) => [asc(verses.number)],
     limit,
     offset,
   })
-<<<<<<< HEAD
-
   if (redis) {
     await redis.set(cacheKey, data, { ex: 60 })
   }
 
   return NextResponse.json(data)
 }
-=======
-
-  if (redis) {
-    await redis.set(cacheKey, data, { ex: 60 })
-  }
-
-  return NextResponse.json(data)
-}
->>>>>>> origin/main

--- a/tests/verses.test.ts
+++ b/tests/verses.test.ts
@@ -1,63 +1,3 @@
-<<<<<<< HEAD
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-
-let GET: any
-let findMany: any
-let redis: any
-
-describe('verses API', () => {
-  beforeEach(async () => {
-    const data = [
-      { id: 'v1', bookId: 'b1', number: 1, text: 'one' },
-      { id: 'v2', bookId: 'b1', number: 2, text: 'two' },
-      { id: 'v3', bookId: 'b1', number: 3, text: 'three' }
-    ]
-    findMany = vi.fn(({ limit, offset }: any) => data.slice(offset, offset + limit))
-
-    const store = new Map<string, any>()
-    redis = {
-      get: vi.fn(async (k: string) => store.get(k)),
-      set: vi.fn(async (k: string, v: any) => {
-        store.set(k, v)
-      })
-    }
-    vi.mock('@upstash/redis', () => ({ Redis: { fromEnv: () => redis } }))
-    vi.mock('@/lib/db', () => ({ db: { query: { verses: { findMany } } } }))
-    vi.mock('@/lib/schema', () => ({ verses: {} }))
-
-    ;({ GET } = await import('../app/api/verses/route'))
-  })
-
-  afterEach(() => {
-    vi.resetModules()
-    vi.clearAllMocks()
-  })
-
-  it('returns paginated verses and caches', async () => {
-    const req = new Request('http://test/verses?bookId=b1&page=0&limit=2')
-    const res1 = await GET(req)
-    const data1 = await res1.json()
-    expect(data1).toHaveLength(2)
-    expect(findMany).toHaveBeenCalledTimes(1)
-
-    const res2 = await GET(req)
-    await res2.json()
-    expect(findMany).toHaveBeenCalledTimes(1)
-    expect(redis.get).toHaveBeenCalledTimes(2)
-  })
-
-  it('returns 400 for missing bookId', async () => {
-    const res = await GET(new Request('http://test/verses'))
-    expect(res.status).toBe(400)
-  })
-
-  it('returns empty array for out-of-bounds page', async () => {
-    const res = await GET(new Request('http://test/verses?bookId=b1&page=10&limit=2'))
-    const data = await res.json()
-    expect(data).toEqual([])
-  })
-})
-=======
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
 const versesData = [
@@ -82,7 +22,7 @@ vi.mock("@/lib/redis", () => ({ redis }));
 vi.mock("@/lib/db", () => ({ db: { query: { verses: { findMany } } } }));
 vi.mock("@/lib/schema", () => ({ verses: {} }));
 
-const { GET } = await import("../app/api/verses/route");
+const { GET } = await import("@/app/api/verses/route");
 
 describe("verses route", () => {
   beforeEach(() => {
@@ -121,4 +61,3 @@ describe("verses route", () => {
     expect(res.status).toBe(400);
   });
 });
->>>>>>> origin/main


### PR DESCRIPTION
## Summary
- import redis using `@/lib/redis` in verses API route
- mock `@/lib/redis` in verses test and import route using path alias

## Testing
- `npm test -- tests/verses.test.ts` *(fails: multiple unrelated tests failing)*
- `npx vitest run tests/verses.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bf45ba4dd88323952857435bef0008