### PR TITLE
feat: expose karma badge metadata with colors

### DIFF
--- a/app/feed/page.tsx
+++ b/app/feed/page.tsx
@@ -1,4 +1,4 @@
-import { formatKarmaBadge } from "@/lib/karma"
+import { getKarmaBadge } from "@/lib/karma"
 import { headers } from "next/headers"
 
 export const dynamic = "force-dynamic"
@@ -32,9 +32,14 @@ export default async function FeedPage() {
           {comments.map((c: any) => (
             <li key={c.id} className="text-sm">
               <span className="font-medium">{c.user.name}</span>
-              <span className="ml-1 text-xs text-muted-foreground">
-                {formatKarmaBadge(c.user.karma)}
-              </span>
+              {(() => {
+                const badge = getKarmaBadge(c.user.karma)
+                return (
+                  <span className={`ml-1 text-xs ${badge.color}`}>
+                    {badge.label}
+                  </span>
+                )
+              })()}
               : {c.content}
             </li>
           ))}
@@ -46,9 +51,14 @@ export default async function FeedPage() {
           {highlights.map((h: any) => (
             <li key={h.id} className="text-sm">
               <span className="font-medium">{h.user.name}</span>
-              <span className="ml-1 text-xs text-muted-foreground">
-                {formatKarmaBadge(h.user.karma)}
-              </span>
+              {(() => {
+                const badge = getKarmaBadge(h.user.karma)
+                return (
+                  <span className={`ml-1 text-xs ${badge.color}`}>
+                    {badge.label}
+                  </span>
+                )
+              })()}
               : {h.content}
             </li>
           ))}

--- a/components/comment-section.tsx
+++ b/components/comment-section.tsx
@@ -1,7 +1,7 @@
 "use client"
 import { useEffect, useState, FormEvent } from "react"
 import { Button } from "@/components/ui/button"
-import { formatKarmaBadge } from "@/lib/karma"
+import { getKarmaBadge } from "@/lib/karma"
 
 interface Comment {
   id: string
@@ -66,9 +66,14 @@ export function CommentSection({ verseId }: { verseId: string }) {
             <div className="flex items-center justify-between">
               <div className="text-sm flex-1">
                 <span className="font-medium">{c.user.name}</span>
-                <span className="ml-1 text-xs text-muted-foreground">
-                  {formatKarmaBadge(c.user.karma)}
-                </span>
+                {(() => {
+                  const badge = getKarmaBadge(c.user.karma)
+                  return (
+                    <span className={`ml-1 text-xs ${badge.color}`}>
+                      {badge.label}
+                    </span>
+                  )
+                })()}
                 : {c.content}
               </div>
               <div className="flex items-center gap-1 ml-2">

--- a/lib/karma.ts
+++ b/lib/karma.ts
@@ -1,11 +1,22 @@
-export function getKarmaBadge(karma: number): string {
-  if (karma >= 1000) return "sage"
-  if (karma >= 500) return "adept"
-  if (karma >= 100) return "apprentice"
-  return "novice"
+export interface KarmaBadge {
+  /** Minimum karma required for this badge */
+  min: number
+  label: string
+  color: string
 }
 
-export function formatKarmaBadge(karma: number): string {
-  const badge = getKarmaBadge(karma)
-  return badge.charAt(0).toUpperCase() + badge.slice(1)
+// Ordered by minimum karma requirement ascending
+export const karmaBadges: KarmaBadge[] = [
+  { min: 0, label: "Novice", color: "text-gray-500" },
+  { min: 100, label: "Contributor", color: "text-green-600" },
+  { min: 500, label: "Adept", color: "text-blue-600" },
+  { min: 1000, label: "Sage", color: "text-purple-600" },
+]
+
+/**
+ * Return the badge information for the given karma value.
+ */
+export function getKarmaBadge(karma: number): { label: string; color: string } {
+  const badge = [...karmaBadges].reverse().find((b) => karma >= b.min) ?? karmaBadges[0]
+  return { label: badge.label, color: badge.color }
 }


### PR DESCRIPTION
## Summary
- return karma badges with label and color
- show colored karma badges in comment and feed lists

## Testing
- `npm test` *(fails: 31 failed, 10 passed)*
- `npx vitest run lib/karma.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c0b50c4df08323b672f6ce22efae33