### PR TITLE
refactor: statically import notification modules

### DIFF
--- a/app/api/comments/route.ts
+++ b/app/api/comments/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server"
 import { promises as fs } from "fs"
 import path from "path"
+import { addKarma } from "@/lib/gamification"
+import { createNotification } from "@/lib/notifications"
 
 export interface Comment {
   id: string
@@ -74,8 +76,8 @@ export async function POST(req: Request) {
   if (!data[verseId]) data[verseId] = []
   data[verseId].push(comment)
   await writeData(data)
+  await addKarma(userId, "comment")
   if (replyToUserId || (Array.isArray(mentions) && mentions.length)) {
-    const { createNotification } = await import("../../../lib/notifications")
     if (replyToUserId) {
       await createNotification(replyToUserId, "reply", content)
     }


### PR DESCRIPTION
## Summary
- statically import `addKarma` and `createNotification` in comments API route
- remove dynamic `await import()` and call `addKarma`

## Testing
- `npx eslint app/api/comments/route.ts && echo 'Lint success'`
- `DATABASE_URL=postgres://user:pass@localhost:5432/db npx vitest tests/api/comments.test.ts` *(fails: ReferenceError: notifications is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b50ba90c832380881fb760c7d27c