### PR TITLE
fix: resolve verses route conflict

### DIFF
--- a/app/api/verses/route.ts
+++ b/app/api/verses/route.ts
@@ -2,33 +2,19 @@ import { NextResponse } from "next/server"
 import { db } from "@/lib/db"
 import { verses } from "@/lib/schema"
 import { eq } from "drizzle-orm"
-<<<<<<< HEAD
 import { redis } from "@/lib/redis"
 
 export async function GET(req: Request) {
-=======
-import { redis } from "../../../lib/redis"
-
-export async function GET(req: Request) {
->>>>>>> origin/main
   const { searchParams } = new URL(req.url)
   const bookId = searchParams.get("bookId")
   const page = Number.parseInt(searchParams.get("page") || "1", 10)
   const limit = Number.parseInt(searchParams.get("limit") || "10", 10)
   const offset = (page - 1) * limit
-<<<<<<< HEAD
 
   if (!bookId) {
     return NextResponse.json({ error: "Missing bookId" }, { status: 400 })
   }
 
-=======
-
-  if (!bookId) {
-    return NextResponse.json({ error: "Missing bookId" }, { status: 400 })
-  }
-
->>>>>>> origin/main
   if (
     !Number.isInteger(page) ||
     page < 1 ||
@@ -37,7 +23,6 @@ export async function GET(req: Request) {
   ) {
     return NextResponse.json({ error: "Invalid pagination" }, { status: 400 })
   }
-<<<<<<< HEAD
 
   const cacheKey = `verses:${bookId}:${page}:${limit}`
   if (redis) {
@@ -47,23 +32,12 @@ export async function GET(req: Request) {
     }
   }
 
-=======
-  const cacheKey = `verses:${bookId}:${page}:${limit}`
-  if (redis) {
-    const cached = await redis.get(cacheKey)
-    if (cached) {
-      return NextResponse.json(cached)
-    }
-  }
-
->>>>>>> origin/main
   const data = await db.query.verses.findMany({
     where: eq(verses.bookId, bookId),
     orderBy: (verses, { asc }) => [asc(verses.number)],
     limit,
     offset,
   })
-<<<<<<< HEAD
 
   if (redis) {
     await redis.set(cacheKey, data, { ex: 60 })
@@ -71,12 +45,4 @@ export async function GET(req: Request) {
 
   return NextResponse.json(data)
 }
-=======
 
-  if (redis) {
-    await redis.set(cacheKey, data, { ex: 60 })
-  }
-
-  return NextResponse.json(data)
-}
->>>>>>> origin/main


### PR DESCRIPTION
## Summary
- unify verses route after merge conflict and use project-relative Redis import
- validate bookId and pagination before DB query
- optionally cache verse results in Redis when available

## Testing
- `pnpm test` *(fails: missing @playwright/test and other conflicts)*
- `npx vitest run app/api/verses/route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c0b6d052048323bde06ffd49bd9118