### PR TITLE
Fix translations API test conflict

### DIFF
--- a/tests/translations.test.ts
+++ b/tests/translations.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-<<<<<<< HEAD
 
 let GET: any
 let findMany: any
@@ -53,66 +52,7 @@ describe('translations API', () => {
 
   it('returns empty array for out-of-bounds page', async () => {
     const res = await GET(new Request('http://test/translations?verseId=v1&page=10&limit=2'))
-=======
-
-let GET: any
-let findMany: any
-let redis: any
-
-describe('translations API', () => {
-  beforeEach(async () => {
-    const data = [
-      { id: 't1', verseId: 'v1', translator: 'a', text: 'A' },
-      { id: 't2', verseId: 'v1', translator: 'b', text: 'B' },
-      { id: 't3', verseId: 'v1', translator: 'c', text: 'C' }
-    ]
-    findMany = vi.fn(({ limit, offset }: any) => data.slice(offset, offset + limit))
-
-    const store = new Map<string, any>()
-    redis = {
-      get: vi.fn(async (k: string) => store.get(k)),
-      set: vi.fn(async (k: string, v: any) => {
-        store.set(k, v)
-      })
-    }
-    vi.mock('@upstash/redis', () => ({ Redis: { fromEnv: () => redis } }))
-    vi.mock('@/lib/db', () => ({ db: { query: { translations: { findMany } } } }))
-    vi.mock('@/lib/schema', () => ({ translations: {} }))
-
-    ;({ GET } = await import('../app/api/translations/route'))
-  })
-
-  afterEach(() => {
-    vi.resetModules()
-    vi.clearAllMocks()
-  })
-
-  it('returns paginated translations and caches', async () => {
-    const req = new Request('http://test/translations?verseId=v1&page=0&limit=2')
-    const res1 = await GET(req)
-    const data1 = await res1.json()
-    expect(data1).toHaveLength(2)
-    expect(findMany).toHaveBeenCalledTimes(1)
-
-    const res2 = await GET(req)
-    await res2.json()
-    expect(findMany).toHaveBeenCalledTimes(1)
-    expect(redis.get).toHaveBeenCalledTimes(2)
-  })
-
-  it('returns 400 for missing verseId', async () => {
-    const res = await GET(new Request('http://test/translations'))
-    expect(res.status).toBe(400)
-  })
-
-  it('returns empty array for out-of-bounds page', async () => {
-    const res = await GET(new Request('http://test/translations?verseId=v1&page=10&limit=2'))
->>>>>>> origin/main
     const data = await res.json()
     expect(data).toEqual([])
   })
 })
-<<<<<<< HEAD
-=======
-
->>>>>>> origin/main


### PR DESCRIPTION
## Summary
- Resolve merge conflict markers in `translations.test.ts`
- Keep single implementation for translations API tests and update imports

## Testing
- `npm test` *(fails: missing dependencies and unresolved merge conflicts in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b6ce84188323b5c145c373e2e01d