### PR TITLE
test: add addKarma persistence test

### DIFF
--- a/lib/gamification.ts
+++ b/lib/gamification.ts
@@ -69,6 +69,8 @@ export async function addKarma(userId: string, type: ActivityType) {
     karma: number
     streak: number
     lastActive: Date | null
+    commentKarma: number
+    highlightKarma: number
   }
   const user = (await db.query.users.findFirst({
     where: eq(users.id, userId),
@@ -85,13 +87,23 @@ export async function addKarma(userId: string, type: ActivityType) {
   else if (diff > 1) streak = 1
 
   const karma = (user.karma ?? 0) + points
+  const commentKarma =
+    (user.commentKarma ?? 0) + (type === "comment" ? points : 0)
+  const highlightKarma =
+    (user.highlightKarma ?? 0) + (type === "highlight" ? points : 0)
 
   await db
     .update(users)
-    .set({ karma, streak, lastActive: now })
+    .set({ karma, streak, lastActive: now, commentKarma, highlightKarma })
     .where(eq(users.id, userId))
 
-  return { karma, streak, badge: getKarmaBadge(karma) }
+  return {
+    karma,
+    commentKarma,
+    highlightKarma,
+    streak,
+    badge: getKarmaBadge(karma),
+  }
 }
 
 export function getBadges(user: {

--- a/tests/gamification.test.ts
+++ b/tests/gamification.test.ts
@@ -1,16 +1,21 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const where = vi.fn().mockResolvedValue(undefined)
+  const set = vi.fn(() => ({ where }))
+  const update = vi.fn(() => ({ set }))
+  const findFirst = vi.fn()
+  return { where, set, update, findFirst }
+})
 
 vi.mock('../lib/db', () => ({
   db: {
-    update: () => ({
-      set: () => ({
-        where: () => ({
-          returning: () => Promise.resolve([]),
-        }),
-      }),
-    }),
+    update: mocks.update,
+    query: { users: { findFirst: mocks.findFirst } },
   },
 }))
+
+vi.mock('../lib/schema', () => ({ users: {} }))
 
 import {
   calculateStreak,
@@ -34,7 +39,46 @@ describe('gamification helpers', () => {
 })
 
 describe('addKarma', () => {
+  beforeEach(() => {
+    mocks.findFirst.mockReset()
+    mocks.update.mockClear()
+    mocks.set.mockClear()
+    mocks.where.mockClear()
+  })
+
   it('throws for invalid user ID', async () => {
+    mocks.findFirst.mockResolvedValue(null)
     await expect(addKarma('invalid', 'comment')).rejects.toThrow()
+  })
+
+  it('updates karma and streak and persists', async () => {
+    const mockUser = {
+      id: 'u1',
+      karma: 10,
+      commentKarma: 4,
+      highlightKarma: 1,
+      streak: 2,
+      lastActive: new Date(Date.now() - 86400000),
+    }
+    mocks.findFirst.mockResolvedValue(mockUser)
+
+    const result = await addKarma('u1', 'comment')
+
+    expect(result.karma).toBe(15)
+    expect(result.commentKarma).toBe(9)
+    expect(result.highlightKarma).toBe(1)
+    expect(result.streak).toBe(3)
+    expect(result.badge.name).toBe('Commentator')
+
+    expect(mocks.update).toHaveBeenCalledTimes(1)
+    expect(mocks.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        karma: 15,
+        commentKarma: 9,
+        highlightKarma: 1,
+        streak: 3,
+        lastActive: expect.any(Date),
+      })
+    )
   })
 })


### PR DESCRIPTION
## Summary
- extend gamification tests with mocked user and db persistence checks
- update addKarma to return updated karma, comment/highlight karma, streak, and badge

## Testing
- `npx vitest run tests/gamification.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c0b50bab608323bf2bc9eb08bd665b