### PR TITLE
feat: add caching for translations endpoint

### DIFF
--- a/app/api/translations/route.test.ts
+++ b/app/api/translations/route.test.ts
@@ -7,12 +7,25 @@ const sample = [
   { id: 't3', verseId: '1', translator: 'C', text: 'three' },
 ]
 
-// mock database
-const findMany = vi.fn(({ limit, offset }) => sample.slice(offset, offset + limit))
+// mock database using chained query builder
+const runQuery = vi.fn((limit: number, offset: number) => sample.slice(offset, offset + limit))
 vi.mock('@/lib/db', () => ({
-  db: { query: { translations: { findMany } } }
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: () => ({
+            limit: (limit: number) => ({
+              offset: (offset: number) => Promise.resolve(runQuery(limit, offset)),
+            }),
+          }),
+        }),
+      }),
+    }),
+  },
 }))
-vi.mock('@/lib/schema', () => ({ translations: {}, verses: {} }))
+vi.mock('@/lib/schema', () => ({ translations: { verseId: {}, translator: {} }, verses: {} }))
+vi.mock('drizzle-orm', () => ({ eq: vi.fn(), asc: vi.fn() }))
 
 // mock redis with in-memory store to verify caching
 const store = new Map<string, any>()
@@ -50,7 +63,7 @@ describe('GET /api/translations', () => {
 
     expect(get).toHaveBeenCalledTimes(2)
     expect(set).toHaveBeenCalledTimes(1)
-    expect(findMany).toHaveBeenCalledTimes(1)
+    expect(runQuery).toHaveBeenCalledTimes(1)
   })
 
   it('returns 400 if verseId missing', async () => {

--- a/app/api/translations/route.ts
+++ b/app/api/translations/route.ts
@@ -1,26 +1,23 @@
 import { NextResponse } from "next/server"
 import { db } from "@/lib/db"
 import { translations } from "@/lib/schema"
-import { eq } from "drizzle-orm"
-import { Redis } from "@upstash/redis"
-
-let redis: Redis | null = null
-try {
-  redis = Redis.fromEnv()
-} catch {
-  redis = null
-}
+import { eq, asc } from "drizzle-orm"
+import { redis } from "@/lib/redis"
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url)
   const verseId = searchParams.get("verseId")
-  const page = parseInt(searchParams.get("page") || "0")
-  const limit = parseInt(searchParams.get("limit") || "5")
+  const page = parseInt(searchParams.get("page") ?? "1", 10)
+  const limit = parseInt(searchParams.get("limit") ?? "5", 10)
 
   if (!verseId) {
     return NextResponse.json({ error: "Missing verseId" }, { status: 400 })
   }
+  if (isNaN(page) || page < 1 || isNaN(limit) || limit < 1) {
+    return NextResponse.json({ error: "Invalid pagination parameters" }, { status: 400 })
+  }
 
+  const offset = (page - 1) * limit
   const cacheKey = `translations:${verseId}:${page}:${limit}`
   if (redis) {
     const cached = await redis.get(cacheKey)
@@ -29,12 +26,13 @@ export async function GET(req: Request) {
     }
   }
 
-  const data = await db.query.translations.findMany({
-    where: eq(translations.verseId, verseId),
-    orderBy: (translations, { asc }) => [asc(translations.translator)],
-    limit,
-    offset: page * limit,
-  })
+  const data = await db
+    .select()
+    .from(translations)
+    .where(eq(translations.verseId, verseId))
+    .orderBy(asc(translations.translator))
+    .limit(limit)
+    .offset(offset)
 
   if (redis) {
     await redis.set(cacheKey, data, { ex: 60 })


### PR DESCRIPTION
## Summary
- sanitize translations API merge markers and implement cache-backed query
- update unit tests for translations pagination and caching

## Testing
- `npm test` *(fails: Failed to resolve import "@playwright/test"; Unexpected "}"; notifications not defined; Transform failed with error; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b50789648323a89d6f898c617f01