### PR TITLE
feat: cache translation responses

### DIFF
--- a/app/api/translations/route.test.ts
+++ b/app/api/translations/route.test.ts
@@ -7,12 +7,21 @@ const sample = [
   { id: 't3', verseId: '1', translator: 'C', text: 'three' },
 ]
 
-// mock database
-const findMany = vi.fn(({ limit, offset }) => sample.slice(offset, offset + limit))
-vi.mock('@/lib/db', () => ({
-  db: { query: { translations: { findMany } } }
+// mock database using chained builders
+const select = vi.fn(() => ({
+  from: vi.fn(() => ({
+    where: vi.fn(() => ({
+      orderBy: vi.fn(() => ({
+        limit: vi.fn((l: number) => ({
+          offset: vi.fn((o: number) => sample.slice(o, o + l)),
+        })),
+      })),
+    })),
+  })),
 }))
-vi.mock('@/lib/schema', () => ({ translations: {}, verses: {} }))
+vi.mock('@/lib/db', () => ({ db: { select } }))
+vi.mock('drizzle-orm', () => ({ eq: () => ({}), asc: () => ({}) }))
+vi.mock('@/lib/schema', () => ({ translations: {} }))
 
 // mock redis with in-memory store to verify caching
 const store = new Map<string, any>()
@@ -50,7 +59,7 @@ describe('GET /api/translations', () => {
 
     expect(get).toHaveBeenCalledTimes(2)
     expect(set).toHaveBeenCalledTimes(1)
-    expect(findMany).toHaveBeenCalledTimes(1)
+    expect(select).toHaveBeenCalledTimes(1)
   })
 
   it('returns 400 if verseId missing', async () => {

--- a/app/api/translations/route.ts
+++ b/app/api/translations/route.ts
@@ -1,24 +1,24 @@
 import { NextResponse } from "next/server"
 import { db } from "@/lib/db"
 import { translations } from "@/lib/schema"
-import { eq } from "drizzle-orm"
-import { Redis } from "@upstash/redis"
-
-let redis: Redis | null = null
-try {
-  redis = Redis.fromEnv()
-} catch {
-  redis = null
-}
+import { eq, asc } from "drizzle-orm"
+import { redis } from "@/lib/redis"
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url)
   const verseId = searchParams.get("verseId")
-  const page = parseInt(searchParams.get("page") || "0")
-  const limit = parseInt(searchParams.get("limit") || "5")
+  const page = parseInt(searchParams.get("page") ?? "1", 10)
+  const limit = parseInt(searchParams.get("limit") ?? "5", 10)
 
   if (!verseId) {
     return NextResponse.json({ error: "Missing verseId" }, { status: 400 })
+  }
+
+  if (isNaN(page) || page <= 0 || isNaN(limit) || limit <= 0) {
+    return NextResponse.json(
+      { error: "Invalid page or limit" },
+      { status: 400 }
+    )
   }
 
   const cacheKey = `translations:${verseId}:${page}:${limit}`
@@ -29,12 +29,14 @@ export async function GET(req: Request) {
     }
   }
 
-  const data = await db.query.translations.findMany({
-    where: eq(translations.verseId, verseId),
-    orderBy: (translations, { asc }) => [asc(translations.translator)],
-    limit,
-    offset: page * limit,
-  })
+  const offset = (page - 1) * limit
+  const data = await db
+    .select()
+    .from(translations)
+    .where(eq(translations.verseId, verseId))
+    .orderBy(asc(translations.translator))
+    .limit(limit)
+    .offset(offset)
 
   if (redis) {
     await redis.set(cacheKey, data, { ex: 60 })


### PR DESCRIPTION
## Summary
- replace Upstash client with shared redis instance
- validate page & limit before querying translations
- cache paginated results in redis

## Testing
- `pnpm test` *(fails: missing dependencies & unresolved conflicts in unrelated files)*
- `npx vitest run app/api/translations/route.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1192d522883238320a4cd8cbe31b4