### PR TITLE
Use static imports for comments gamification and notifications

### DIFF
--- a/app/api/comments/route.ts
+++ b/app/api/comments/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server"
 import { promises as fs } from "fs"
 import path from "path"
+import { addKarma } from "@/lib/gamification"
+import { createNotification } from "@/lib/notifications"
 
 export interface Comment {
   id: string
@@ -74,8 +76,8 @@ export async function POST(req: Request) {
   if (!data[verseId]) data[verseId] = []
   data[verseId].push(comment)
   await writeData(data)
+  await addKarma(userId, "comment")
   if (replyToUserId || (Array.isArray(mentions) && mentions.length)) {
-    const { createNotification } = await import("../../../lib/notifications")
     if (replyToUserId) {
       await createNotification(replyToUserId, "reply", content)
     }


### PR DESCRIPTION
## Summary
- statically import `addKarma` and `createNotification` in comments API
- award karma on comment creation and send notifications without dynamic imports

## Testing
- `npx tsc --noEmit app/api/comments/route.ts`
- `npx vitest run tests/api/comments.test.ts` *(fails: Cannot find module '.prisma/client/default')*


------
https://chatgpt.com/codex/tasks/task_e_68c13438a6288323854f7316dee7cc8b