### PR TITLE
feat: expose karma badge metadata

### DIFF
--- a/app/feed/page.tsx
+++ b/app/feed/page.tsx
@@ -1,4 +1,4 @@
-import { formatKarmaBadge } from "@/lib/karma"
+import { getKarmaBadge } from "@/lib/karma"
 import { headers } from "next/headers"
 
 export const dynamic = "force-dynamic"
@@ -32,9 +32,12 @@ export default async function FeedPage() {
           {comments.map((c: any) => (
             <li key={c.id} className="text-sm">
               <span className="font-medium">{c.user.name}</span>
-              <span className="ml-1 text-xs text-muted-foreground">
-                {formatKarmaBadge(c.user.karma)}
-              </span>
+              {(() => {
+                const badge = getKarmaBadge(c.user.karma)
+                return (
+                  <span className={`ml-1 text-xs ${badge.color}`}>{badge.label}</span>
+                )
+              })()}
               : {c.content}
             </li>
           ))}
@@ -46,9 +49,12 @@ export default async function FeedPage() {
           {highlights.map((h: any) => (
             <li key={h.id} className="text-sm">
               <span className="font-medium">{h.user.name}</span>
-              <span className="ml-1 text-xs text-muted-foreground">
-                {formatKarmaBadge(h.user.karma)}
-              </span>
+              {(() => {
+                const badge = getKarmaBadge(h.user.karma)
+                return (
+                  <span className={`ml-1 text-xs ${badge.color}`}>{badge.label}</span>
+                )
+              })()}
               : {h.content}
             </li>
           ))}

--- a/components/comment-section.tsx
+++ b/components/comment-section.tsx
@@ -1,7 +1,7 @@
 "use client"
 import { useEffect, useState, FormEvent } from "react"
 import { Button } from "@/components/ui/button"
-import { formatKarmaBadge } from "@/lib/karma"
+import { getKarmaBadge } from "@/lib/karma"
 
 interface Comment {
   id: string
@@ -66,9 +66,12 @@ export function CommentSection({ verseId }: { verseId: string }) {
             <div className="flex items-center justify-between">
               <div className="text-sm flex-1">
                 <span className="font-medium">{c.user.name}</span>
-                <span className="ml-1 text-xs text-muted-foreground">
-                  {formatKarmaBadge(c.user.karma)}
-                </span>
+                {(() => {
+                  const badge = getKarmaBadge(c.user.karma)
+                  return (
+                    <span className={`ml-1 text-xs ${badge.color}`}>{badge.label}</span>
+                  )
+                })()}
                 : {c.content}
               </div>
               <div className="flex items-center gap-1 ml-2">

--- a/lib/karma.ts
+++ b/lib/karma.ts
@@ -1,11 +1,29 @@
-export function getKarmaBadge(karma: number): string {
-  if (karma >= 1000) return "sage"
-  if (karma >= 500) return "adept"
-  if (karma >= 100) return "apprentice"
-  return "novice"
+export interface KarmaBadge {
+  /** Minimum karma required for this badge */
+  min: number
+  /** Display label for the badge */
+  label: string
+  /** Tailwind text color class */
+  color: string
 }
 
-export function formatKarmaBadge(karma: number): string {
-  const badge = getKarmaBadge(karma)
-  return badge.charAt(0).toUpperCase() + badge.slice(1)
+/**
+ * Metadata describing available karma badges and their thresholds.
+ * Badges are ordered from highest to lowest requirement.
+ */
+export const karmaBadges: KarmaBadge[] = [
+  { min: 1000, label: "Sage", color: "text-purple-600" },
+  { min: 500, label: "Adept", color: "text-blue-600" },
+  { min: 100, label: "Contributor", color: "text-green-600" },
+  { min: 0, label: "Novice", color: "text-gray-500" },
+]
+
+/**
+ * Return the badge that corresponds to a user's karma value.
+ */
+export function getKarmaBadge(karma: number): Omit<KarmaBadge, 'min'> {
+  const { label, color } =
+    karmaBadges.find((badge) => karma >= badge.min) ?? karmaBadges[karmaBadges.length - 1]
+  return { label, color }
 }
+


### PR DESCRIPTION
## Summary
- return karma badge objects with label and color
- show colored badge labels in comment and feed sections

## Testing
- `bun test lib/karma.test.ts`
- `bun test tests/gamification.test.ts` *(fails: Cannot find module '.prisma/client/default')*
- `bunx tsc -p tsconfig.json --noEmit` *(fails: many TypeScript errors due to merge conflict markers)*

------
https://chatgpt.com/codex/tasks/task_e_68c134398e60832389f61f0dae5c5f29