### PR TITLE
test: add karma persistence tests

### DIFF
--- a/lib/gamification.ts
+++ b/lib/gamification.ts
@@ -67,12 +67,14 @@ export async function addKarma(userId: string, type: ActivityType) {
   const points = KARMA_VALUES[type]
   type UserStats = {
     karma: number
+    commentKarma: number
+    highlightKarma: number
     streak: number
     lastActive: Date | null
   }
   const user = (await db.query.users.findFirst({
     where: eq(users.id, userId),
-  })) as (UserStats | null)
+  })) as UserStats | null
   if (!user) {
     throw new Error(`User with id ${userId} not found`)
   }
@@ -85,13 +87,23 @@ export async function addKarma(userId: string, type: ActivityType) {
   else if (diff > 1) streak = 1
 
   const karma = (user.karma ?? 0) + points
+  let commentKarma = user.commentKarma ?? 0
+  let highlightKarma = user.highlightKarma ?? 0
+  if (type === "comment") commentKarma += points
+  if (type === "highlight") highlightKarma += points
 
   await db
     .update(users)
-    .set({ karma, streak, lastActive: now })
+    .set({ karma, commentKarma, highlightKarma, streak, lastActive: now })
     .where(eq(users.id, userId))
 
-  return { karma, streak, badge: getKarmaBadge(karma) }
+  return {
+    karma,
+    commentKarma,
+    highlightKarma,
+    streak,
+    badge: getKarmaBadge(karma),
+  }
 }
 
 export function getBadges(user: {

--- a/tests/gamification.test.ts
+++ b/tests/gamification.test.ts
@@ -1,16 +1,21 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const { findFirstMock, updateMock, setMock, whereMock } = vi.hoisted(() => {
+  const whereMock = vi.fn(() => Promise.resolve())
+  const setMock = vi.fn(() => ({ where: whereMock }))
+  const updateMock = vi.fn(() => ({ set: setMock }))
+  const findFirstMock = vi.fn()
+  return { findFirstMock, updateMock, setMock, whereMock }
+})
 
 vi.mock('../lib/db', () => ({
   db: {
-    update: () => ({
-      set: () => ({
-        where: () => ({
-          returning: () => Promise.resolve([]),
-        }),
-      }),
-    }),
+    query: { users: { findFirst: findFirstMock } },
+    update: updateMock,
   },
 }))
+
+vi.mock('../lib/schema', () => ({ users: {} }))
 
 import {
   calculateStreak,
@@ -34,7 +39,74 @@ describe('gamification helpers', () => {
 })
 
 describe('addKarma', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('updates comment karma and persists changes', async () => {
+    const user = {
+      id: '1',
+      karma: 0,
+      commentKarma: 0,
+      highlightKarma: 0,
+      streak: 1,
+      lastActive: new Date(Date.now() - 86_400_000),
+    }
+    findFirstMock.mockResolvedValueOnce(user)
+
+    const result = await addKarma('1', 'comment')
+
+    expect(result.karma).toBe(5)
+    expect(result.commentKarma).toBe(5)
+    expect(result.highlightKarma).toBe(0)
+    expect(result.streak).toBe(2)
+    expect(result.badge.name).toBe('Novice')
+
+    expect(updateMock).toHaveBeenCalledOnce()
+    expect(setMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        karma: 5,
+        commentKarma: 5,
+        highlightKarma: 0,
+        streak: 2,
+        lastActive: expect.any(Date),
+      })
+    )
+  })
+
+  it('updates highlight karma and persists changes', async () => {
+    const user = {
+      id: '1',
+      karma: 5,
+      commentKarma: 5,
+      highlightKarma: 0,
+      streak: 1,
+      lastActive: new Date(Date.now() - 86_400_000),
+    }
+    findFirstMock.mockResolvedValueOnce(user)
+
+    const result = await addKarma('1', 'highlight')
+
+    expect(result.karma).toBe(7)
+    expect(result.commentKarma).toBe(5)
+    expect(result.highlightKarma).toBe(2)
+    expect(result.streak).toBe(2)
+    expect(result.badge.name).toBe('Novice')
+
+    expect(updateMock).toHaveBeenCalledOnce()
+    expect(setMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        karma: 7,
+        commentKarma: 5,
+        highlightKarma: 2,
+        streak: 2,
+        lastActive: expect.any(Date),
+      })
+    )
+  })
+
   it('throws for invalid user ID', async () => {
+    findFirstMock.mockResolvedValueOnce(null)
     await expect(addKarma('invalid', 'comment')).rejects.toThrow()
   })
 })


### PR DESCRIPTION
## Summary
- extend `addKarma` to track comment and highlight karma, return badge
- verify karma persistence with new gamification tests

## Testing
- `pnpm exec vitest run tests/gamification.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c13438d1988323b124c9a9df47a7fe