### PR TITLE
feat: add validation and rate limiting to auth routes

### DIFF
--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -2,14 +2,29 @@ import { PrismaClient } from "@prisma/client"
 import { NextResponse } from "next/server"
 import { randomUUID } from "crypto"
 import nodemailer from "nodemailer"
+import { z } from "zod"
+import { rateLimit } from "@/lib/rate-limit"
 
 const prisma = new PrismaClient()
 
+const bodySchema = z.object({ email: z.string().email() })
+
 export async function POST(req: Request) {
-  const { email } = await req.json()
-  if (!email) {
-    return NextResponse.json({ error: "Email required" }, { status: 400 })
+  const ip =
+    req.headers.get("x-real-ip") ||
+    req.headers.get("x-forwarded-for")?.split(",")[0] ||
+    "unknown"
+  const allowed = await rateLimit(`reset-password:${ip}`, 5, 60)
+  if (!allowed) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 })
   }
+
+  const parse = bodySchema.safeParse(await req.json())
+  if (!parse.success) {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 })
+  }
+  const { email } = parse.data
+
   const user = await prisma.user.findUnique({ where: { email } })
   if (!user) {
     return NextResponse.json({ ok: true })

--- a/app/api/auth/reset/route.ts
+++ b/app/api/auth/reset/route.ts
@@ -1,45 +1,29 @@
 import { NextResponse } from "next/server"
-<<<<<<< HEAD
-import { db } from "@/lib/db"
-import { users, sessions } from "@/lib/schema"
-import { eq } from "drizzle-orm"
-import { v4 as uuid } from "uuid"
-import nodemailer from "nodemailer"
-
-export async function POST(req: Request) {
-  const { email } = await req.json()
-  const user = await db.query.users.findFirst({ where: eq(users.email, email) })
-  if (user) {
-    const token = uuid()
-    const expires = new Date(Date.now() + 60 * 60 * 1000)
-    await db.insert(sessions).values({ id: token, userId: user.id, expiresAt: expires })
-
-    const transporter = nodemailer.createTransport({
-      host: process.env.EMAIL_SERVER_HOST,
-      port: Number(process.env.EMAIL_SERVER_PORT),
-      auth: {
-        user: process.env.EMAIL_SERVER_USER,
-        pass: process.env.EMAIL_SERVER_PASSWORD,
-      },
-    })
-
-    const resetUrl = `${process.env.NEXTAUTH_URL}/auth/reset/${token}`
-    await transporter.sendMail({
-      to: email,
-      from: process.env.EMAIL_FROM!,
-      subject: "Password Reset",
-      text: `Reset your password: ${resetUrl}`,
-    })
-  }
-=======
 import { PrismaClient } from "@prisma/client"
 import { randomBytes } from "crypto"
 import nodemailer from "nodemailer"
+import { z } from "zod"
+import { rateLimit } from "@/lib/rate-limit"
 
 const prisma = new PrismaClient()
+const bodySchema = z.object({ email: z.string().email() })
 
 export async function POST(req: Request) {
-  const { email } = await req.json()
+  const ip =
+    req.headers.get("x-real-ip") ||
+    req.headers.get("x-forwarded-for")?.split(",")[0] ||
+    "unknown"
+  const allowed = await rateLimit(`reset:${ip}`, 5, 60)
+  if (!allowed) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 })
+  }
+
+  const parse = bodySchema.safeParse(await req.json())
+  if (!parse.success) {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 })
+  }
+  const { email } = parse.data
+
   const user = await prisma.user.findUnique({ where: { email } })
   if (!user) {
     return NextResponse.json({ error: "User not found" }, { status: 404 })
@@ -64,6 +48,5 @@ export async function POST(req: Request) {
     text: `Reset your password: ${resetUrl}`,
   })
 
->>>>>>> origin/codex/implement-auth-routes-and-features
   return NextResponse.json({ ok: true })
 }

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,27 +1,32 @@
 import { NextResponse } from "next/server"
 import { PrismaClient } from "@prisma/client"
 import { hash } from "bcryptjs"
+import { z } from "zod"
+import { rateLimit } from "@/lib/rate-limit"
 
 const prisma = new PrismaClient()
 
+const signupSchema = z.object({
+  email: z.string().email(),
+  username: z.string().min(1),
+  password: z.string().min(6),
+})
+
 export async function POST(req: Request) {
-  const { email, username, password } = await req.json()
-  if (
-    typeof email !== "string" ||
-    typeof username !== "string" ||
-    typeof password !== "string"
-  ) {
-    return NextResponse.json({ error: "Missing fields" }, { status: 400 })
+  const ip =
+    req.headers.get("x-real-ip") ||
+    req.headers.get("x-forwarded-for")?.split(",")[0] ||
+    "unknown"
+  const allowed = await rateLimit(`signup:${ip}`, 5, 60)
+  if (!allowed) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 })
   }
-  if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
-    return NextResponse.json({ error: "Invalid email" }, { status: 400 })
+
+  const parse = signupSchema.safeParse(await req.json())
+  if (!parse.success) {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 })
   }
-  if (password.length < 6) {
-    return NextResponse.json(
-      { error: "Password must be at least 6 characters" },
-      { status: 400 }
-    )
-  }
+  const { email, username, password } = parse.data
   const existing = await prisma.user.findFirst({
     where: { OR: [{ email }, { username }] },
   })

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,27 @@
+import { redis } from './redis'
+
+const localCache = new Map<string, { count: number; timestamp: number }>()
+
+export async function rateLimit(
+  key: string,
+  limit: number,
+  windowSeconds: number
+): Promise<boolean> {
+  if (redis) {
+    const count = await redis.incr(key)
+    if (count === 1) {
+      await redis.expire(key, windowSeconds)
+    }
+    return count <= limit
+  }
+
+  const now = Date.now()
+  const record = localCache.get(key) || { count: 0, timestamp: now }
+  if (now - record.timestamp > windowSeconds * 1000) {
+    record.count = 0
+    record.timestamp = now
+  }
+  record.count += 1
+  localCache.set(key, record)
+  return record.count <= limit
+}

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "sqlite3": "^5.1.7",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",


### PR DESCRIPTION
## Summary
- validate auth request bodies with zod
- throttle auth endpoints via Redis-backed rate limiter
- add consistent error handling for invalid input and too many requests

## Testing
- `pnpm test` *(fails: Failed to resolve import "@playwright/test" and multiple failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c1345a778c8323ac514c39610ff9a7