### PR TITLE
Add validation and rate limiting to auth routes

### DIFF
--- a/app/api/auth/reset-password/[token]/route.ts
+++ b/app/api/auth/reset-password/[token]/route.ts
@@ -1,19 +1,35 @@
-import { PrismaClient } from "@prisma/client"
+import { prisma } from "@/lib/db"
 import { NextResponse } from "next/server"
 import bcrypt from "bcryptjs"
+import { z } from "zod"
+import { rateLimit } from "@/lib/rate-limit"
 
-const prisma = new PrismaClient()
+const schema = z.object({ password: z.string().min(6) })
 
-export async function POST(req: Request, { params }: { params: { token: string } }) {
-  const { password } = await req.json()
-  if (!password) {
-    return NextResponse.json({ error: "Password required" }, { status: 400 })
+export async function POST(
+  req: Request,
+  { params }: { params: { token: string } },
+) {
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0] ||
+    req.headers.get("x-real-ip") ||
+    "unknown"
+
+  if (await rateLimit(`reset-password:${ip}`)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 })
   }
+
+  const parsed = schema.safeParse(await req.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 })
+  }
+
+  const { password } = parsed.data
   const record = await prisma.verificationToken.findUnique({
     where: { token: params.token },
   })
   if (!record || record.expires < new Date()) {
-    return NextResponse.json({ error: "Invalid token" }, { status: 400 })
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 })
   }
   const hashed = await bcrypt.hash(password, 10)
   await prisma.user.update({

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -1,15 +1,28 @@
-import { PrismaClient } from "@prisma/client"
 import { NextResponse } from "next/server"
+import { prisma } from "@/lib/db"
 import { randomUUID } from "crypto"
 import nodemailer from "nodemailer"
+import { z } from "zod"
+import { rateLimit } from "@/lib/rate-limit"
 
-const prisma = new PrismaClient()
+const schema = z.object({ email: z.string().email() })
 
 export async function POST(req: Request) {
-  const { email } = await req.json()
-  if (!email) {
-    return NextResponse.json({ error: "Email required" }, { status: 400 })
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0] ||
+    req.headers.get("x-real-ip") ||
+    "unknown"
+
+  if (await rateLimit(`reset-password:${ip}`)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 })
   }
+
+  const parsed = schema.safeParse(await req.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 })
+  }
+
+  const { email } = parsed.data
   const user = await prisma.user.findUnique({ where: { email } })
   if (!user) {
     return NextResponse.json({ ok: true })

--- a/app/api/auth/reset/[token]/route.ts
+++ b/app/api/auth/reset/[token]/route.ts
@@ -1,43 +1,36 @@
 import { NextResponse } from "next/server"
-<<<<<<< HEAD
-import { db } from "@/lib/db"
-import { sessions, users } from "@/lib/schema"
-import { eq } from "drizzle-orm"
-import bcrypt from "bcryptjs"
+import { prisma } from "@/lib/db"
+import { hash } from "bcryptjs"
+import { z } from "zod"
+import { rateLimit } from "@/lib/rate-limit"
+
+const schema = z.object({ password: z.string().min(6) })
 
 export async function POST(
   req: Request,
   { params }: { params: { token: string } },
 ) {
-  const { password } = await req.json()
-  const token = params.token
-  const record = await db.query.sessions.findFirst({
-    where: eq(sessions.id, token),
-  })
-  if (!record || record.expiresAt < new Date()) {
-    return NextResponse.json({ error: "Invalid token" }, { status: 400 })
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0] ||
+    req.headers.get("x-real-ip") ||
+    "unknown"
+
+  if (await rateLimit(`reset:${ip}`)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 })
   }
-  const hashed = await bcrypt.hash(password, 10)
-  await db
-    .update(users)
-    .set({ password: hashed, updatedAt: new Date() })
-    .where(eq(users.id, record.userId))
-  await db.delete(sessions).where(eq(sessions.id, token))
-=======
-import { PrismaClient } from "@prisma/client"
-import { hash } from "bcryptjs"
 
-const prisma = new PrismaClient()
+  const parsed = schema.safeParse(await req.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 })
+  }
 
-export async function POST(req: Request, { params }: { params: { token: string } }) {
-  const { password } = await req.json()
+  const { password } = parsed.data
   const session = await prisma.session.findUnique({ where: { sessionToken: params.token } })
   if (!session || session.expires < new Date()) {
-    return NextResponse.json({ error: "Invalid or expired token" }, { status: 400 })
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 })
   }
   const hashed = await hash(password, 10)
   await prisma.user.update({ where: { id: session.userId }, data: { password: hashed } })
   await prisma.session.delete({ where: { sessionToken: params.token } })
->>>>>>> origin/codex/implement-auth-routes-and-features
   return NextResponse.json({ ok: true })
 }

--- a/app/api/auth/reset/route.ts
+++ b/app/api/auth/reset/route.ts
@@ -1,48 +1,31 @@
 import { NextResponse } from "next/server"
-<<<<<<< HEAD
-import { db } from "@/lib/db"
-import { users, sessions } from "@/lib/schema"
-import { eq } from "drizzle-orm"
-import { v4 as uuid } from "uuid"
-import nodemailer from "nodemailer"
-
-export async function POST(req: Request) {
-  const { email } = await req.json()
-  const user = await db.query.users.findFirst({ where: eq(users.email, email) })
-  if (user) {
-    const token = uuid()
-    const expires = new Date(Date.now() + 60 * 60 * 1000)
-    await db.insert(sessions).values({ id: token, userId: user.id, expiresAt: expires })
-
-    const transporter = nodemailer.createTransport({
-      host: process.env.EMAIL_SERVER_HOST,
-      port: Number(process.env.EMAIL_SERVER_PORT),
-      auth: {
-        user: process.env.EMAIL_SERVER_USER,
-        pass: process.env.EMAIL_SERVER_PASSWORD,
-      },
-    })
-
-    const resetUrl = `${process.env.NEXTAUTH_URL}/auth/reset/${token}`
-    await transporter.sendMail({
-      to: email,
-      from: process.env.EMAIL_FROM!,
-      subject: "Password Reset",
-      text: `Reset your password: ${resetUrl}`,
-    })
-  }
-=======
-import { PrismaClient } from "@prisma/client"
+import { prisma } from "@/lib/db"
 import { randomBytes } from "crypto"
 import nodemailer from "nodemailer"
+import { z } from "zod"
+import { rateLimit } from "@/lib/rate-limit"
 
-const prisma = new PrismaClient()
+const schema = z.object({ email: z.string().email() })
 
 export async function POST(req: Request) {
-  const { email } = await req.json()
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0] ||
+    req.headers.get("x-real-ip") ||
+    "unknown"
+
+  if (await rateLimit(`reset:${ip}`)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 })
+  }
+
+  const parsed = schema.safeParse(await req.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 })
+  }
+
+  const { email } = parsed.data
   const user = await prisma.user.findUnique({ where: { email } })
   if (!user) {
-    return NextResponse.json({ error: "User not found" }, { status: 404 })
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 })
   }
   const token = randomBytes(32).toString("hex")
   const expires = new Date(Date.now() + 1000 * 60 * 60)
@@ -64,6 +47,5 @@ export async function POST(req: Request) {
     text: `Reset your password: ${resetUrl}`,
   })
 
->>>>>>> origin/codex/implement-auth-routes-and-features
   return NextResponse.json({ ok: true })
 }

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,27 +1,32 @@
 import { NextResponse } from "next/server"
-import { PrismaClient } from "@prisma/client"
+import { prisma } from "@/lib/db"
 import { hash } from "bcryptjs"
+import { z } from "zod"
+import { rateLimit } from "@/lib/rate-limit"
 
-const prisma = new PrismaClient()
+const schema = z.object({
+  email: z.string().email(),
+  username: z.string().min(1),
+  password: z.string().min(6),
+})
 
 export async function POST(req: Request) {
-  const { email, username, password } = await req.json()
-  if (
-    typeof email !== "string" ||
-    typeof username !== "string" ||
-    typeof password !== "string"
-  ) {
-    return NextResponse.json({ error: "Missing fields" }, { status: 400 })
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0] ||
+    req.headers.get("x-real-ip") ||
+    "unknown"
+
+  if (await rateLimit(`signup:${ip}`)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 })
   }
-  if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
-    return NextResponse.json({ error: "Invalid email" }, { status: 400 })
+
+  const parsed = schema.safeParse(await req.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 })
   }
-  if (password.length < 6) {
-    return NextResponse.json(
-      { error: "Password must be at least 6 characters" },
-      { status: 400 }
-    )
-  }
+
+  const { email, username, password } = parsed.data
+
   const existing = await prisma.user.findFirst({
     where: { OR: [{ email }, { username }] },
   })

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,26 @@
+import { redis } from './redis'
+
+const WINDOW_SECONDS = 60
+const MAX_REQUESTS = 5
+
+const memory = new Map<string, { count: number; expires: number }>()
+
+export async function rateLimit(identifier: string): Promise<boolean> {
+  if (redis) {
+    const count = await redis.incr(identifier)
+    if (count === 1) {
+      await redis.expire(identifier, WINDOW_SECONDS)
+    }
+    return count > MAX_REQUESTS
+  }
+
+  const now = Date.now()
+  const record = memory.get(identifier) || { count: 0, expires: now + WINDOW_SECONDS * 1000 }
+  if (record.expires < now) {
+    record.count = 0
+    record.expires = now + WINDOW_SECONDS * 1000
+  }
+  record.count += 1
+  memory.set(identifier, record)
+  return record.count > MAX_REQUESTS
+}

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "sqlite3": "^5.1.7",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
+      zod:
+        specifier: ^3.22.4
+        version: 3.25.76
     devDependencies:
       '@testing-library/react':
         specifier: ^16.3.0
@@ -4439,7 +4442,6 @@ packages:
 
   libsql@0.5.17:
     resolution: {integrity: sha512-RRlj5XQI9+Wq+/5UY8EnugSWfRmHEw4hn3DKlPrkUgZONsge1PwTtHcpStP6MSNi8ohcbsRgEHJaymA33a8cBw==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lighthouse-logger@1.4.2:
@@ -6593,6 +6595,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
@@ -14334,3 +14339,5 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zod@3.25.76: {}


### PR DESCRIPTION
## Summary
- add zod validation and throttling to signup and password reset endpoints
- introduce shared rate limiter backed by Redis or memory
- standardize error responses for invalid input and too many requests

## Testing
- `pnpm test` *(fails: Failed to resolve imports and other existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c1347973608323adaab32f01144c0c